### PR TITLE
refactor: portfolio overhaul v3.0 — identity, curation, new projects

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -5361,3 +5361,378 @@ section {
     padding-top: var(--spacing-lg);
   }
 }
+   v3.0 OVERHAUL — NEW COMPONENT STYLES
+   ============================================================ */
+
+/* ── Currently Block ── */
+.currently-block {
+  margin-top: var(--spacing-lg);
+  padding: 0.75rem 1rem;
+  border-left: 2px solid var(--accent-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-tertiary);
+  line-height: 1.5;
+}
+
+.currently-block strong {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.currently-block a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.currently-block a:hover strong {
+  color: var(--accent-secondary);
+}
+
+.currently-label {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-secondary);
+  margin-right: 0.5em;
+}
+
+/* ── Practice Grid (replaces skill bars) ── */
+.practice-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--spacing-lg);
+  margin-bottom: var(--spacing-xl);
+}
+
+@media (max-width: 767px) {
+  .practice-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.practice-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--bg-tertiary);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  position: relative;
+  transition: border-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.practice-card:hover {
+  border-color: var(--accent-secondary);
+  transform: translateY(-2px);
+}
+
+.practice-number {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+  letter-spacing: 0.08em;
+  display: block;
+  margin-bottom: 0.75rem;
+}
+
+.practice-card h3 {
+  font-size: 1.1rem;
+  margin-bottom: 0.6rem;
+  color: var(--text-primary);
+}
+
+.practice-card p {
+  font-size: 0.9rem;
+  line-height: 1.65;
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-md);
+}
+
+.practice-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.practice-tags span {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--text-tertiary);
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-sm);
+  padding: 0.2em 0.55em;
+  letter-spacing: 0.03em;
+}
+
+/* ── Code Preview Cards (for projects without screenshots) ── */
+.code-preview-card .project-image {
+  background: var(--preview-bg, #0a0a0a);
+  min-height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.code-preview-card .project-image::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at 30% 40%, color-mix(in srgb, var(--preview-accent, #c8ff00) 12%, transparent), transparent 65%);
+  pointer-events: none;
+}
+
+.code-preview {
+  width: 100%;
+  height: 100%;
+  min-height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.code-preview-inner {
+  width: 100%;
+  max-width: 320px;
+}
+
+.code-preview-sigil {
+  font-family: var(--font-mono);
+  font-size: 2.8rem;
+  font-weight: 500;
+  color: var(--preview-accent, #c8ff00);
+  letter-spacing: 0.05em;
+  line-height: 1;
+  margin-bottom: 1rem;
+  text-shadow: 0 0 40px color-mix(in srgb, var(--preview-accent, #c8ff00) 40%, transparent);
+}
+
+.code-preview-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin-bottom: 1.25rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--preview-accent, #c8ff00) 20%, transparent);
+}
+
+.code-preview-label {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: color-mix(in srgb, var(--preview-accent, #c8ff00) 60%, white);
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+}
+
+.code-preview-url {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  color: color-mix(in srgb, white 30%, transparent);
+  letter-spacing: 0.04em;
+}
+
+.code-preview-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.cpl {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  display: flex;
+  gap: 0.75em;
+}
+
+.cpl-k {
+  color: color-mix(in srgb, white 35%, transparent);
+  min-width: 5em;
+}
+
+.cpl-v {
+  color: color-mix(in srgb, white 60%, transparent);
+}
+
+.cpl-active {
+  color: var(--preview-accent, #c8ff00);
+}
+
+/* ── Status badge: build type ── */
+.status-badge.build {
+  background: rgba(67, 233, 123, 0.12);
+  color: #43e97b;
+  border: 1px solid rgba(67, 233, 123, 0.2);
+}
+
+/* ── Info page improvements ── */
+.info-section {
+  padding: var(--spacing-xxl) 0;
+}
+
+.info-section h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2rem, 5vw, 3rem);
+  margin-bottom: var(--spacing-xl);
+  color: var(--text-primary);
+}
+
+.info-content {
+  max-width: 640px;
+}
+
+.info-links {
+  margin-bottom: var(--spacing-xl);
+  padding-bottom: var(--spacing-xl);
+  border-bottom: 1px solid var(--bg-tertiary);
+}
+
+.info-links:last-child {
+  border-bottom: none;
+}
+
+.info-links h2 {
+  font-size: 1.1rem;
+  margin-bottom: var(--spacing-md);
+  color: var(--text-primary);
+}
+
+.info-links p {
+  font-size: 0.92rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.5rem;
+}
+
+.info-links a {
+  color: var(--accent-secondary);
+  text-decoration: none;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+}
+
+.info-links a:hover {
+  color: var(--accent-tertiary);
+}
+
+.info-links-eyebrow {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  margin-bottom: 0.5rem;
+}
+
+.info-links-subtle h2 {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.quiet-links {
+  list-style: none;
+  padding: 0;
+  margin: var(--spacing-md) 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.quiet-links li a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-family: var(--font-body);
+  transition: color var(--transition-fast);
+}
+
+.quiet-links li a::before {
+  content: '↗';
+  font-size: 0.7em;
+  color: var(--accent-secondary);
+  font-family: var(--font-mono);
+}
+
+.quiet-links li a:hover {
+  color: var(--text-primary);
+}
+
+/* ── Remove old skill-bar styles from rendered output ── */
+.skill-item,
+.skill-bar,
+.skill-progress,
+.technical-skills,
+.creative-capabilities,
+.workflow-list,
+.workflow-step {
+  /* Retained for backwards compat if JS references them, but hidden visually */
+  display: none;
+}
+
+/* ── Project card: remove fake stat rows ── */
+.project-stats {
+  display: none;
+}
+
+/* ── Small refinements to existing components ── */
+.hero-title {
+  letter-spacing: -0.02em;
+}
+
+.section-title {
+  letter-spacing: -0.015em;
+}
+
+/* Subtle grain overlay on hero */
+.hero-section::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.03'/%3E%3C/svg%3E");
+  pointer-events: none;
+  opacity: 0.4;
+  z-index: 0;
+}
+
+.hero-section {
+  position: relative;
+}
+
+.hero-section .container {
+  position: relative;
+  z-index: 1;
+}
+
+/* ── Dark theme code preview adjustments ── */
+[data-theme="dark"] .practice-card,
+.theme-dark .practice-card {
+  background: var(--bg-secondary);
+  border-color: var(--bg-tertiary);
+}
+
+[data-theme="dark"] .practice-tags span,
+.theme-dark .practice-tags span {
+  background: var(--bg-tertiary);
+}
+
+/* ── Mobile: currently block ── */
+@media (max-width: 480px) {
+  .currently-block {
+    font-size: 0.72rem;
+  }
+}
+
+/* ── Accessibility: reduce motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .practice-card:hover {
+    transform: none;
+  }
+  .code-preview-card .project-image::before {
+    display: none;
+  }
+}

--- a/public/data/project-details.json
+++ b/public/data/project-details.json
@@ -1,5 +1,116 @@
 [
   {
+    "slug": "mvxworld",
+    "title": "mvxworld.art",
+    "fullDescriptionHtml": "\n            <p><strong>mvxworld.art</strong> is a personal identity hub and living archive — not a portfolio, but a world. Each page is a room discovered rather than a section bolted on. The site grows organically, page by page, as a transmission from a multi-handle internet native who treats design, code, and culture as one practice.</p>\n            <h4>What the project is showing</h4>\n            <ul>\n                <li><strong>Custom design system:</strong> A fully hand-rolled CSS token system with a dark archive aesthetic — ink base (#0a0a09), acid green (#c8ff00), and a Cormorant Garamond × IBM Plex Mono type pairing</li>\n                <li><strong>Transmissions engine:</strong> A manifest-driven post system where adding new content is two paste steps and a push — no CMS, no build step</li>\n                <li><strong>World architecture:</strong> Six live rooms (index, lore, work, gallery, transmissions archive, individual posts) each breaking one design rule as the accent</li>\n                <li><strong>No framework:</strong> Vanilla HTML, CSS, and JS — a deliberate constraint that keeps the site fast and fully in control</li>\n            </ul>\n        ",
+    "technologies": [
+      "Vanilla HTML/CSS/JS",
+      "Custom Design System",
+      "World-building",
+      "Identity Design",
+      "Transmissions Engine"
+    ],
+    "liveUrl": "https://mvxworld.art",
+    "media": [
+      {
+        "type": "image",
+        "src": "img/mvxworld-preview.jpg",
+        "alt": "mvxworld.art homepage — dark archive aesthetic",
+        "caption": "The main world — dark, atmospheric, five rooms",
+        "frame": "wide",
+        "width": 1800,
+        "height": 1000
+      }
+    ],
+    "collections": [
+      {
+        "title": "The World",
+        "description": "mvxworld.art runs on a custom design system with one rule: every room breaks one convention as the accent. The result is a site that feels intentional without feeling corporate.",
+        "media": []
+      }
+    ]
+  },
+  {
+    "slug": "kaar",
+    "title": "KAAR",
+    "fullDescriptionHtml": "\n            <p><strong>KAAR</strong> is a multiplayer touch-arena party app prototype built in Expo React Native. Everyone places a finger on screen, the room locks in, and a dramatic reveal picks the outcome. The core loop is tactile setup, social suspense, and an exaggerated reveal — then instant replay.</p>\n            <h4>What the project is showing</h4>\n            <ul>\n                <li><strong>Product thinking from scratch:</strong> Full brief, feature map, UX flow, design system, and architecture — all defined before a line of code</li>\n                <li><strong>Multi-touch engineering:</strong> Custom touch arena tracking 1–8 simultaneous finger positions with fair and chaos selection modes kept separate in code</li>\n                <li><strong>Design system:</strong> Custom tokens (electricLime, hyperCoral, laserBlue), theme switching between prototype and collab modes, reduced-motion awareness</li>\n                <li><strong>Shipped features:</strong> Game modes, scoreboard, dare prompts, haptics, session history, local persistence, original sound pack, PWA-style offline behavior</li>\n            </ul>\n        ",
+    "technologies": [
+      "React Native",
+      "Expo",
+      "TypeScript",
+      "Multi-touch",
+      "Design System",
+      "Product Design"
+    ],
+    "liveUrl": "https://github.com/Trijbs/KAAR",
+    "media": [
+      {
+        "type": "image",
+        "src": "img/kaar-preview.jpg",
+        "alt": "KAAR multiplayer party app interface",
+        "caption": "Touch arena with multi-finger detection",
+        "frame": "portrait",
+        "width": 390,
+        "height": 844
+      }
+    ],
+    "collections": [
+      {
+        "title": "App Architecture",
+        "description": "KAAR was built around a strict separation of fair randomness and chaos logic — ensuring transparent, auditable game outcomes in fair mode with no hidden manipulation.",
+        "media": []
+      }
+    ]
+  },
+  {
+    "slug": "weekplanner",
+    "title": "WeekPlanner",
+    "fullDescriptionHtml": "\n            <p><strong>WeekPlanner</strong> is a structured week-planning app with hourly time blocks, assignees, thought threads, and real-time sync. Built as a full-stack production app with automated cron sync and a PWA setup — not a tutorial project.</p>\n            <h4>What the project is showing</h4>\n            <ul>\n                <li><strong>Full-stack architecture:</strong> Next.js frontend, Supabase backend with migrations, RLS policies, and an automated hourly sync cron via Vault refresh</li>\n                <li><strong>Feature depth:</strong> Hour blocks, assignee support, thought thread inbox, end-of-week date logic, week-over-week navigation</li>\n                <li><strong>Production setup:</strong> CodeQL security scanning, automated deployment workflows, PWA icons, proper TypeScript across the stack</li>\n                <li><strong>Design quality:</strong> Clean, opinionated UI — mockups were built before development, then matched exactly in the final product</li>\n            </ul>\n        ",
+    "technologies": [
+      "Next.js",
+      "TypeScript",
+      "Supabase",
+      "PostgreSQL",
+      "PWA",
+      "Tailwind CSS"
+    ],
+    "liveUrl": "https://weekplanner.trijbsworld.nl",
+    "media": [
+      {
+        "type": "image",
+        "src": "img/weekplanner-preview.jpg",
+        "alt": "WeekPlanner app — hourly time blocks and thought threads",
+        "caption": "Week view with hour blocks and thought thread inbox",
+        "frame": "wide",
+        "width": 1440,
+        "height": 900
+      }
+    ],
+    "collections": [
+      {
+        "title": "App Overview",
+        "description": "WeekPlanner was designed mockup-first: the full UI was sketched in HTML before any backend work started. The result is a product where design and implementation stayed in sync throughout.",
+        "media": []
+      }
+    ]
+  },
+  {
+    "slug": "tainment",
+    "title": "Tainment",
+    "fullDescriptionHtml": "\n            <p><strong>Tainment</strong> is a Discord bot ecosystem built across two repos — a Python discord.py bot with casino mechanics, fishing games, and subscription management, and a Node.js companion (VibeBit) with trivia, leaderboards, and community features. Built because it should exist, not because it was assigned.</p>\n            <h4>What the project is showing</h4>\n            <ul>\n                <li><strong>Systems thinking:</strong> Two separate bots with overlapping community use cases, each optimized for its runtime (Python for the casino/economy layer, Node.js for real-time community features)</li>\n                <li><strong>Feature breadth:</strong> Casino (roulette, slots), fishing with XP and leaderboards, trivia, birthday tracking, admin subscriptions, automod, welcome messages</li>\n                <li><strong>Persistent data:</strong> SQLite and JSON-based data layers, XP systems, member tracking, guild-level configuration</li>\n                <li><strong>Automation mentality:</strong> Built to run unsupervised — the kind of project that shows how I think about systems, not just interfaces</li>\n            </ul>\n        ",
+    "technologies": [
+      "Python",
+      "discord.py",
+      "Node.js",
+      "SQLite",
+      "Automation",
+      "Community Tools"
+    ],
+    "liveUrl": "https://github.com/Tribsy/tainment",
+    "media": [],
+    "collections": []
+  },
+  {
     "slug": "urban-unleashed",
     "title": "Urban Unleashed",
     "fullDescriptionHtml": "\n            <p><strong>Urban Unleashed</strong> is an interface-led landing page concept where visual atmosphere, motion, and interaction work together. The project is less about showing raw technology and more about how a bold digital first impression can still feel usable.</p>\n            <h4>What the project is showing</h4>\n            <ul>\n                <li><strong>Landing-page composition:</strong> Hero framing, visual focus, and a strong first-screen impact</li>\n                <li><strong>Immersive interface thinking:</strong> Motion and 3D styling used to support the brand feel instead of overwhelming it</li>\n                <li><strong>Responsive execution:</strong> The concept is built to stay visually coherent across screen sizes</li>\n            </ul>\n        ",
@@ -78,112 +189,6 @@
             "height": 1125
           }
         ]
-      }
-    ]
-  },
-  {
-    "slug": "webshop",
-    "title": "E-commerce Platform",
-    "fullDescriptionHtml": "\n            <p><strong>E-commerce Platform</strong> is a webshop concept focused on product visibility, conversion hierarchy, and a smoother browsing-to-checkout flow. The project is included here as interface work rather than as a full technical case study.</p>\n            <h4>What the project is showing</h4>\n            <ul>\n                <li><strong>Product-first layout:</strong> Product imagery and calls-to-action stay visually clear</li>\n                <li><strong>Usability:</strong> Navigation, listing, and purchase flow are designed to feel direct and trustworthy</li>\n                <li><strong>Consistency:</strong> Repeated UI patterns help the store feel stable across sections</li>\n            </ul>\n        ",
-    "technologies": [
-      "React",
-      "Node.js",
-      "MongoDB",
-      "Stripe API",
-      "E-commerce UI"
-    ],
-    "liveUrl": "https://trijbs.eu/Webshop/",
-    "media": [
-      {
-        "type": "image",
-        "src": "img/Webshop.webp",
-        "alt": "Webshop homepage preview",
-        "caption": "Conversion-focused storefront concept",
-        "frame": "wide",
-        "width": 1000,
-        "height": 510
-      }
-    ],
-    "collections": [
-      {
-        "title": "Storefront Preview",
-        "description": "A screen capture of the main webshop interface.",
-        "media": [
-          {
-            "type": "image",
-            "src": "img/Webshop.webp",
-            "alt": "Webshop preview image",
-            "caption": "Product-led e-commerce layout",
-            "frame": "wide",
-            "width": 1000,
-            "height": 510
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "slug": "motion-design-studies",
-    "title": "Animated Infographic",
-    "fullDescriptionHtml": "\n            <p><strong>Animated Infographic</strong> is a motion-led information design piece built around pacing, contrast, and sequencing. The goal is to make the information easier to follow by giving every transition and visual shift a clear role.</p>\n            <h4>What the project is showing</h4>\n            <ul>\n                <li><strong>Information hierarchy in motion:</strong> Each scene uses timing and contrast to direct attention toward the next key point</li>\n                <li><strong>Readable animation:</strong> Movement supports the content instead of competing with it</li>\n                <li><strong>Narrative pacing:</strong> The full piece is structured as a visual explanation rather than a loose animation experiment</li>\n            </ul>\n        ",
-    "technologies": [
-      "Motion Design",
-      "Animation",
-      "Information Design",
-      "Visual Storytelling"
-    ],
-    "media": [
-      {
-        "type": "video",
-        "src": "videos/archive/infographic.mp4",
-        "poster": "img/archive/infographic-poster.png",
-        "alt": "Animated infographic preview",
-        "caption": "Animated infographic preview",
-        "frame": "wide",
-        "posterWidth": 1200,
-        "posterHeight": 675
-      }
-    ],
-    "collections": [
-      {
-        "title": "Animated Infographic",
-        "description": "A motion-led piece where timing, contrast, and sequencing are used to explain information clearly.",
-        "media": [
-          {
-            "type": "video",
-            "src": "videos/archive/infographic.mp4",
-            "poster": "img/archive/infographic-poster.png",
-            "alt": "Animated infographic video",
-            "caption": "Motion-driven infographic piece",
-            "frame": "wide",
-            "posterWidth": 1200,
-            "posterHeight": 675
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "slug": "video-editing-remake",
-    "title": "Video Editing Remake",
-    "fullDescriptionHtml": "\n            <p><strong>Video Editing Remake</strong> is a short timing study built around pacing, shot order, and cleaner transitions. The split-screen setup makes the edit decisions visible instead of hiding them behind effects.</p>\n            <h4>What the project is showing</h4>\n            <ul>\n                <li><strong>Editing rhythm:</strong> Cut timing shapes the pace from shot to shot</li>\n                <li><strong>Split-screen comparison:</strong> The remake and reference can be judged side by side</li>\n                <li><strong>Cleaner transitions:</strong> The focus stays on control and flow, not extra effects</li>\n            </ul>\n        ",
-    "technologies": [
-      "Video Editing",
-      "Pacing",
-      "Transition Design",
-      "Motion Study",
-      "Shot Matching"
-    ],
-    "media": [
-      {
-        "type": "video",
-        "src": "videos/archive/video-namaak-editen.mp4",
-        "poster": "img/archive/video-namaak-editen-poster.png",
-        "alt": "Video editing remake preview",
-        "caption": "Split-screen remake study",
-        "frame": "wide",
-        "posterWidth": 1600,
-        "posterHeight": 720
       }
     ]
   },
@@ -312,147 +317,6 @@
     ]
   },
   {
-    "slug": "sire-diabetes-campaign",
-    "title": "SIRE Diabetes Campaign",
-    "fullDescriptionHtml": "\n            <p><strong>SIRE Diabetes Campaign</strong> is a public-awareness concept that turns sugar consumption into a clearer print message. The layouts use direct headlines, food imagery, and short copy to keep the campaign urgent and readable.</p>\n            <h4>Why the work belongs together</h4>\n            <ul>\n                <li><strong>Clear awareness angle:</strong> The message links sugar consumption to broader health consequences</li>\n                <li><strong>Shared call to action:</strong> Each page supports the same petition-led message</li>\n                <li><strong>Consistent print system:</strong> Type, spacing, and image treatment stay steady across the set</li>\n            </ul>\n        ",
-    "technologies": [
-      "Campaign Design",
-      "Health Awareness",
-      "Print Layout",
-      "Typography",
-      "Public Communication"
-    ],
-    "links": [
-      {
-        "href": "files/sire-diabetes.pdf",
-        "label": "Open PDF",
-        "icon": "file-text",
-        "tone": "secondary"
-      }
-    ],
-    "media": [
-      {
-        "type": "image",
-        "src": "img/archive/sire-diabetes/sire-diabetes-01.png",
-        "alt": "SIRE diabetes campaign cover spread",
-        "caption": "Campaign opener",
-        "frame": "wide",
-        "width": 1275,
-        "height": 924
-      }
-    ],
-    "collections": [
-      {
-        "title": "Campaign Pages",
-        "description": "The full three-page sequence showing the campaign message, supporting copy, and call to action.",
-        "media": [
-          {
-            "type": "image",
-            "src": "img/archive/sire-diabetes/sire-diabetes-01.png",
-            "alt": "SIRE diabetes campaign page 1",
-            "caption": "Page 01",
-            "frame": "wide",
-            "width": 1275,
-            "height": 924
-          },
-          {
-            "type": "image",
-            "src": "img/archive/sire-diabetes/sire-diabetes-02.png",
-            "alt": "SIRE diabetes campaign page 2",
-            "caption": "Page 02",
-            "frame": "wide",
-            "width": 1275,
-            "height": 924
-          },
-          {
-            "type": "image",
-            "src": "img/archive/sire-diabetes/sire-diabetes-03.png",
-            "alt": "SIRE diabetes campaign page 3",
-            "caption": "Page 03",
-            "frame": "wide",
-            "width": 1275,
-            "height": 924
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "slug": "figurative-photo-spread",
-    "title": "Figurative Photo Spread",
-    "fullDescriptionHtml": "\n            <p><strong>Figurative Photo Spread</strong> is a four-page editorial study that combines image-led layout, typography references, and design theory in one consistent sequence. It works best as a full spread set because the pacing between pages is part of the result.</p>\n            <h4>Why the work belongs together</h4>\n            <ul>\n                <li><strong>Editorial flow:</strong> Each page shifts topic without losing the same rhythm</li>\n                <li><strong>Layout-led explanation:</strong> The composition helps explain the theory instead of only decorating it</li>\n                <li><strong>One print language:</strong> The orange accent, spacing, and image treatment hold the set together</li>\n            </ul>\n        ",
-    "technologies": [
-      "Editorial Design",
-      "Typography",
-      "Print Layout",
-      "Photography Theory",
-      "Adobe InDesign"
-    ],
-    "links": [
-      {
-        "href": "files/spread-week-3.pdf",
-        "label": "Open PDF",
-        "icon": "file-text",
-        "tone": "secondary"
-      }
-    ],
-    "media": [
-      {
-        "type": "image",
-        "src": "img/archive/spread-week-3/spread-week-3-01.png",
-        "alt": "Figurative photo spread cover page",
-        "caption": "Page 01 - Figuratieve foto",
-        "frame": "portrait",
-        "width": 1275,
-        "height": 1768
-      }
-    ],
-    "collections": [
-      {
-        "title": "Four-Page Spread",
-        "description": "A four-page editorial sequence covering figurative photography, abstract photography, letterforms, and shape versus negative space.",
-        "media": [
-          {
-            "type": "image",
-            "src": "img/archive/spread-week-3/spread-week-3-01.png",
-            "alt": "Figurative photo spread page 1",
-            "caption": "Page 01",
-            "frame": "portrait",
-            "width": 1275,
-            "height": 1768
-          },
-          {
-            "type": "image",
-            "src": "img/archive/spread-week-3/spread-week-3-02.png",
-            "alt": "Figurative photo spread page 2",
-            "caption": "Page 02",
-            "frame": "portrait",
-            "width": 1275,
-            "height": 1768
-          },
-          {
-            "type": "image",
-            "src": "img/archive/spread-week-3/spread-week-3-03.png",
-            "alt": "Figurative photo spread page 3",
-            "caption": "Page 03",
-            "frame": "portrait",
-            "width": 1275,
-            "height": 1768
-          },
-          {
-            "type": "image",
-            "src": "img/archive/spread-week-3/spread-week-3-04.png",
-            "alt": "Figurative photo spread page 4",
-            "caption": "Page 04",
-            "frame": "portrait",
-            "width": 1275,
-            "height": 1768
-          }
-        ]
-      }
-    ]
-  },
-  {
     "slug": "northface-campaign",
     "title": "The North Face Digital Campaign",
     "fullDescriptionHtml": "\n            <p><strong>The North Face Digital Campaign</strong> is shown here as a focused interface rollout rather than a mixed archive. The project is strongest as a set of mobile screens and CRM-style touchpoints built around product visibility, promotional hierarchy, and a consistent retail look.</p>\n            <h4>Why the work belongs together</h4>\n            <ul>\n                <li><strong>Retail consistency:</strong> Product promotion, navigation, and campaign messaging keep the same brand direction throughout the set</li>\n                <li><strong>Mobile-first layout:</strong> The strongest assets focus on phone-sized screens, product grids, and supporting campaign pages</li>\n                <li><strong>CRM support:</strong> The email piece shows how the same campaign language carries into a direct customer touchpoint</li>\n            </ul>\n        ",
@@ -547,55 +411,6 @@
             "frame": "portrait",
             "width": 422,
             "height": 1800
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "slug": "research-concept-boards",
-    "title": "Research & Concept Boards",
-    "fullDescriptionHtml": "\n            <p><strong>Research & Concept Boards</strong> collects the work that happens before a final deliverable is locked. These pieces show how references, collage, and typography experiments help shape a clearer visual direction.</p>\n            <h4>Why the work belongs together</h4>\n            <ul>\n                <li><strong>Early-stage thinking:</strong> These files support decision-making before final design execution</li>\n                <li><strong>Visual direction:</strong> They establish tone, references, and possible styling routes</li>\n                <li><strong>Concept development:</strong> They make the creative process visible, not just the final output</li>\n            </ul>\n        ",
-    "technologies": [
-      "Research Boards",
-      "Collage",
-      "Typography",
-      "Concept Development",
-      "Art Direction"
-    ],
-    "media": [
-      {
-        "type": "image",
-        "src": "img/archive/research-boards/alternative-typo.jpg",
-        "alt": "Alternative typography concept board",
-        "caption": "Typography-led concept board",
-        "frame": "portrait",
-        "width": 1200,
-        "height": 1600
-      }
-    ],
-    "collections": [
-      {
-        "title": "Research Boards",
-        "description": "Reference-heavy visual studies used to shape tone and direction.",
-        "media": [
-          {
-            "type": "image",
-            "src": "img/archive/research-boards/alternative-typo.jpg",
-            "alt": "Alternative typography collage",
-            "caption": "Typography collage experiment",
-            "frame": "portrait",
-            "width": 1200,
-            "height": 1600
-          },
-          {
-            "type": "image",
-            "src": "img/archive/research-boards/balenciaga.jpg",
-            "alt": "Balenciaga research board",
-            "caption": "Fashion and campaign reference board",
-            "frame": "wide",
-            "width": 1800,
-            "height": 1272
           }
         ]
       }
@@ -714,536 +529,6 @@
             "frame": "wide",
             "posterWidth": 1200,
             "posterHeight": 675
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "slug": "editorial-booklets",
-    "title": "Editorial Layout Collection",
-    "fullDescriptionHtml": "\n            <p><strong>Editorial Layout Collection</strong> is organized as a set of browsable page sequences instead of a few loose cover images. That makes the editorial work read properly as pacing, page rhythm, hierarchy, and spread design.</p>\n            <h4>Why the work belongs together</h4>\n            <ul>\n                <li><strong>Booklet thinking:</strong> The projects are meant to be read across multiple pages</li>\n                <li><strong>Editorial rhythm:</strong> Typography, image placement, and white space change from spread to spread</li>\n                <li><strong>Print structure:</strong> Each sequence shows how layout decisions build over time, not in isolation</li>\n            </ul>\n        ",
-    "technologies": [
-      "Editorial Design",
-      "Booklet Layout",
-      "Typography",
-      "Print Composition",
-      "Page Rhythm"
-    ],
-    "media": [
-      {
-        "type": "image",
-        "src": "img/archive/editorial-trends/trends-01.jpg",
-        "alt": "10 Trends of Graphic Design cover",
-        "caption": "10 Trends of Graphic Design",
-        "frame": "portrait",
-        "width": 1184,
-        "height": 1600
-      }
-    ],
-    "collections": [
-      {
-        "title": "10 Trends of Graphic Design",
-        "description": "A multi-page editorial project shown as a browsable sequence so the booklet reads like an actual publication.",
-        "media": [
-          {
-            "type": "image",
-            "src": "img/archive/editorial-trends/trends-01.jpg",
-            "alt": "10 Trends page 1",
-            "caption": "Page 01",
-            "frame": "portrait",
-            "width": 1184,
-            "height": 1600
-          },
-          {
-            "type": "image",
-            "src": "img/archive/editorial-trends/trends-02.jpg",
-            "alt": "10 Trends page 2",
-            "caption": "Page 02",
-            "frame": "portrait",
-            "width": 1600,
-            "height": 1081
-          },
-          {
-            "type": "image",
-            "src": "img/archive/editorial-trends/trends-03.jpg",
-            "alt": "10 Trends page 3",
-            "caption": "Page 03",
-            "frame": "portrait",
-            "width": 1600,
-            "height": 1081
-          },
-          {
-            "type": "image",
-            "src": "img/archive/editorial-trends/trends-04.jpg",
-            "alt": "10 Trends page 4",
-            "caption": "Page 04",
-            "frame": "portrait",
-            "width": 1600,
-            "height": 1081
-          },
-          {
-            "type": "image",
-            "src": "img/archive/editorial-trends/trends-05.jpg",
-            "alt": "10 Trends page 5",
-            "caption": "Page 05",
-            "frame": "portrait",
-            "width": 1600,
-            "height": 1081
-          },
-          {
-            "type": "image",
-            "src": "img/archive/editorial-trends/trends-06.jpg",
-            "alt": "10 Trends page 6",
-            "caption": "Page 06",
-            "frame": "portrait",
-            "width": 1600,
-            "height": 1081
-          },
-          {
-            "type": "image",
-            "src": "img/archive/editorial-trends/trends-07.jpg",
-            "alt": "10 Trends page 7",
-            "caption": "Page 07",
-            "frame": "portrait",
-            "width": 1600,
-            "height": 1081
-          },
-          {
-            "type": "image",
-            "src": "img/archive/editorial-trends/trends-08.jpg",
-            "alt": "10 Trends page 8",
-            "caption": "Page 08",
-            "frame": "portrait",
-            "width": 1600,
-            "height": 1081
-          },
-          {
-            "type": "image",
-            "src": "img/archive/editorial-trends/trends-09.jpg",
-            "alt": "10 Trends page 9",
-            "caption": "Page 09",
-            "frame": "portrait",
-            "width": 1184,
-            "height": 1600
-          }
-        ]
-      },
-      {
-        "title": "Eigen boekje",
-        "description": "A second booklet sequence focused on spread rhythm, image placement, and typography across multiple pages.",
-        "media": [
-          {
-            "type": "image",
-            "src": "img/archive/editorial-booklet/booklet-01.jpg",
-            "alt": "Eigen boekje spread 1",
-            "caption": "Spread 01",
-            "frame": "landscape",
-            "width": 1600,
-            "height": 1184
-          },
-          {
-            "type": "image",
-            "src": "img/archive/editorial-booklet/booklet-02.jpg",
-            "alt": "Eigen boekje spread 2",
-            "caption": "Spread 02",
-            "frame": "landscape",
-            "width": 1600,
-            "height": 592
-          },
-          {
-            "type": "image",
-            "src": "img/archive/editorial-booklet/booklet-03.jpg",
-            "alt": "Eigen boekje spread 3",
-            "caption": "Spread 03",
-            "frame": "landscape",
-            "width": 1600,
-            "height": 592
-          },
-          {
-            "type": "image",
-            "src": "img/archive/editorial-booklet/booklet-04.jpg",
-            "alt": "Eigen boekje spread 4",
-            "caption": "Spread 04",
-            "frame": "landscape",
-            "width": 1600,
-            "height": 592
-          },
-          {
-            "type": "image",
-            "src": "img/archive/editorial-booklet/booklet-05.jpg",
-            "alt": "Eigen boekje spread 5",
-            "caption": "Spread 05",
-            "frame": "landscape",
-            "width": 1600,
-            "height": 592
-          },
-          {
-            "type": "image",
-            "src": "img/archive/editorial-booklet/booklet-06.jpg",
-            "alt": "Eigen boekje spread 6",
-            "caption": "Spread 06",
-            "frame": "landscape",
-            "width": 1600,
-            "height": 592
-          },
-          {
-            "type": "image",
-            "src": "img/archive/editorial-booklet/booklet-07.jpg",
-            "alt": "Eigen boekje spread 7",
-            "caption": "Spread 07",
-            "frame": "landscape",
-            "width": 1600,
-            "height": 1184
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "slug": "poster-series",
-    "title": "Poster Collection",
-    "fullDescriptionHtml": "\n            <p><strong>Poster Collection</strong> brings the poster work together as one graphic exploration set. The files vary in subject, but the shared goal is the same: strong single-frame impact, readable hierarchy, and deliberate image treatment.</p>\n            <h4>Why the work belongs together</h4>\n            <ul>\n                <li><strong>One-frame communication:</strong> Each piece has to land quickly</li>\n                <li><strong>Graphic experimentation:</strong> Color, contrast, and editing changes are part of the process</li>\n                <li><strong>Print-led visuals:</strong> Typography and imagery are combined as one poster system</li>\n            </ul>\n        ",
-    "technologies": [
-      "Poster Design",
-      "Image Treatment",
-      "Typography",
-      "Composition",
-      "Print Visuals"
-    ],
-    "media": [
-      {
-        "type": "image",
-        "src": "img/archive/posters/poster-bowie.jpg",
-        "alt": "David Bowie poster",
-        "caption": "David Bowie poster",
-        "frame": "portrait",
-        "width": 1261,
-        "height": 1800
-      }
-    ],
-    "collections": [
-      {
-        "title": "Poster Series",
-        "description": "A grouped set of poster experiments, from music posters to image-treatment studies.",
-        "media": [
-          {
-            "type": "image",
-            "src": "img/archive/posters/poster-bowie.jpg",
-            "alt": "David Bowie poster",
-            "caption": "David Bowie poster",
-            "frame": "portrait",
-            "width": 1261,
-            "height": 1800
-          },
-          {
-            "type": "image",
-            "src": "img/archive/posters/poster-01-original.jpg",
-            "alt": "Poster original version",
-            "caption": "Original version",
-            "frame": "portrait",
-            "width": 1162,
-            "height": 1600
-          },
-          {
-            "type": "image",
-            "src": "img/archive/posters/poster-02-tone.jpg",
-            "alt": "Poster tone adjustment",
-            "caption": "Tone adjustment",
-            "frame": "portrait",
-            "width": 1142,
-            "height": 1600
-          },
-          {
-            "type": "image",
-            "src": "img/archive/posters/poster-03-contrast.jpg",
-            "alt": "Poster contrast study",
-            "caption": "Contrast study",
-            "frame": "portrait",
-            "width": 1161,
-            "height": 1600
-          },
-          {
-            "type": "image",
-            "src": "img/archive/posters/poster-04-mix.jpg",
-            "alt": "Poster color mix study",
-            "caption": "Two-color mix",
-            "frame": "portrait",
-            "width": 1157,
-            "height": 1600
-          },
-          {
-            "type": "image",
-            "src": "img/archive/posters/poster-05-door.jpg",
-            "alt": "Poster with door and sunlight",
-            "caption": "Door & sunlight",
-            "frame": "portrait",
-            "width": 1316,
-            "height": 1600
-          },
-          {
-            "type": "image",
-            "src": "img/archive/posters/poster-06-glass.jpg",
-            "alt": "Glass poster study",
-            "caption": "Glass study",
-            "frame": "portrait",
-            "width": 1202,
-            "height": 1600
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "slug": "event-promo-pack",
-    "title": "Event Identity Kit",
-    "fullDescriptionHtml": "\n            <p><strong>Event Identity Kit</strong> groups the event flyers and tickets into one identity system. Shown together, they communicate much better than separate files because the consistency between awareness and attendance materials becomes visible.</p>\n            <h4>Why the work belongs together</h4>\n            <ul>\n                <li><strong>Shared event language:</strong> Flyers and tickets use the same visual voice</li>\n                <li><strong>Touchpoint consistency:</strong> Promotion and on-entry materials feel connected</li>\n                <li><strong>Campaign logic:</strong> The set works as one announcement-to-attendance flow</li>\n            </ul>\n        ",
-    "technologies": [
-      "Event Design",
-      "Flyers",
-      "Ticket Design",
-      "Print Promotion",
-      "Identity System"
-    ],
-    "media": [
-      {
-        "type": "image",
-        "src": "img/archive/event-kit/flyer-01.jpg",
-        "alt": "Event flyer",
-        "caption": "Flyer 01",
-        "frame": "portrait",
-        "width": 1127,
-        "height": 1600
-      }
-    ],
-    "collections": [
-      {
-        "title": "Event Assets",
-        "description": "Flyers and tickets grouped as one event identity instead of standalone prints.",
-        "media": [
-          {
-            "type": "image",
-            "src": "img/archive/event-kit/flyer-01.jpg",
-            "alt": "Event flyer 1",
-            "caption": "Flyer 01",
-            "frame": "portrait",
-            "width": 1127,
-            "height": 1600
-          },
-          {
-            "type": "image",
-            "src": "img/archive/event-kit/flyer-02.jpg",
-            "alt": "Event flyer 2",
-            "caption": "Flyer 02",
-            "frame": "portrait",
-            "width": 1127,
-            "height": 1600
-          },
-          {
-            "type": "image",
-            "src": "img/archive/event-kit/ticket-01.jpg",
-            "alt": "Event ticket 1",
-            "caption": "Ticket 01",
-            "frame": "landscape",
-            "width": 1600,
-            "height": 676
-          },
-          {
-            "type": "image",
-            "src": "img/archive/event-kit/ticket-02.jpg",
-            "alt": "Event ticket 2",
-            "caption": "Ticket 02",
-            "frame": "landscape",
-            "width": 1600,
-            "height": 676
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "slug": "menu-design-system",
-    "title": "Hospitality Menu System",
-    "fullDescriptionHtml": "\n            <p><strong>Hospitality Menu System</strong> is presented as a browsable set of pages so the structure of the menu can be read properly. The strength of this work is not one single page, but the consistency across the entire set.</p>\n            <h4>Why the work belongs together</h4>\n            <ul>\n                <li><strong>System thinking:</strong> The menu works through repeated layout rules across categories</li>\n                <li><strong>Readable hierarchy:</strong> Prices, headings, and descriptions stay clear throughout the set</li>\n                <li><strong>Hospitality context:</strong> Decorative styling supports the brand without hurting clarity</li>\n            </ul>\n        ",
-    "technologies": [
-      "Information Design",
-      "Menu Layout",
-      "Typography",
-      "Print Design",
-      "Hospitality"
-    ],
-    "media": [
-      {
-        "type": "image",
-        "src": "img/archive/menu-system/menu-03.jpg",
-        "alt": "Hospitality menu feature spread",
-        "caption": "Feature menu spread",
-        "frame": "landscape",
-        "width": 1600,
-        "height": 1135
-      }
-    ],
-    "collections": [
-      {
-        "title": "Menu Pages",
-        "description": "The full menu sequence grouped together as one hospitality print system.",
-        "media": [
-          {
-            "type": "image",
-            "src": "img/archive/menu-system/menu-01.jpg",
-            "alt": "Menu page 1",
-            "caption": "Page 01",
-            "frame": "portrait",
-            "width": 1127,
-            "height": 1600
-          },
-          {
-            "type": "image",
-            "src": "img/archive/menu-system/menu-02.jpg",
-            "alt": "Menu page 2",
-            "caption": "Page 02",
-            "frame": "landscape",
-            "width": 1600,
-            "height": 1135
-          },
-          {
-            "type": "image",
-            "src": "img/archive/menu-system/menu-03.jpg",
-            "alt": "Menu page 3",
-            "caption": "Page 03",
-            "frame": "landscape",
-            "width": 1600,
-            "height": 1135
-          },
-          {
-            "type": "image",
-            "src": "img/archive/menu-system/menu-04.jpg",
-            "alt": "Menu page 4",
-            "caption": "Page 04",
-            "frame": "landscape",
-            "width": 1600,
-            "height": 1135
-          },
-          {
-            "type": "image",
-            "src": "img/archive/menu-system/menu-05.jpg",
-            "alt": "Menu page 5",
-            "caption": "Page 05",
-            "frame": "landscape",
-            "width": 1600,
-            "height": 1135
-          },
-          {
-            "type": "image",
-            "src": "img/archive/menu-system/menu-06.jpg",
-            "alt": "Menu page 6",
-            "caption": "Page 06",
-            "frame": "portrait",
-            "width": 1127,
-            "height": 1600
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "slug": "photography-studies",
-    "title": "Product Styling Photo Series",
-    "fullDescriptionHtml": "\n            <p><strong>Product Styling Photo Series</strong> is grouped as a set of related image studies around one object family. The value is in seeing the different compositions, lighting moods, and framing decisions next to each other.</p>\n            <h4>Why the work belongs together</h4>\n            <ul>\n                <li><strong>Object consistency:</strong> The same subject is explored in multiple visual treatments</li>\n                <li><strong>Composition studies:</strong> Framing and styling are tested across the set</li>\n                <li><strong>Presentation logic:</strong> The collage and the individual shots support each other</li>\n            </ul>\n        ",
-    "technologies": [
-      "Photography",
-      "Product Styling",
-      "Composition",
-      "Collage",
-      "Art Direction"
-    ],
-    "media": [
-      {
-        "type": "image",
-        "src": "img/archive/photo-series/photo-collage.jpg",
-        "alt": "Photography collage overview",
-        "caption": "Collage overview",
-        "frame": "tall",
-        "width": 1273,
-        "height": 1800
-      }
-    ],
-    "collections": [
-      {
-        "title": "Photo Series",
-        "description": "The collage and the individual product studies grouped into one sequence.",
-        "media": [
-          {
-            "type": "image",
-            "src": "img/archive/photo-series/photo-01.jpg",
-            "alt": "Product photo 1",
-            "caption": "Lead styling shot",
-            "frame": "landscape",
-            "width": 1800,
-            "height": 1200
-          },
-          {
-            "type": "image",
-            "src": "img/archive/photo-series/photo-collage.jpg",
-            "alt": "Photography collage",
-            "caption": "Collage overview",
-            "frame": "tall",
-            "width": 1273,
-            "height": 1800
-          },
-          {
-            "type": "image",
-            "src": "img/archive/photo-series/photo-02.jpg",
-            "alt": "Product photo 2",
-            "caption": "Photo 02",
-            "frame": "landscape",
-            "width": 1800,
-            "height": 1200
-          },
-          {
-            "type": "image",
-            "src": "img/archive/photo-series/photo-03.jpg",
-            "alt": "Product photo 3",
-            "caption": "Photo 03",
-            "frame": "landscape",
-            "width": 1800,
-            "height": 1200
-          },
-          {
-            "type": "image",
-            "src": "img/archive/photo-series/photo-04.jpg",
-            "alt": "Product photo 4",
-            "caption": "Photo 04",
-            "frame": "landscape",
-            "width": 1800,
-            "height": 1200
-          },
-          {
-            "type": "image",
-            "src": "img/archive/photo-series/photo-05.jpg",
-            "alt": "Product photo 5",
-            "caption": "Photo 05",
-            "frame": "landscape",
-            "width": 1800,
-            "height": 1200
-          },
-          {
-            "type": "image",
-            "src": "img/archive/photo-series/photo-06.jpg",
-            "alt": "Product photo 6",
-            "caption": "Photo 06",
-            "frame": "landscape",
-            "width": 1800,
-            "height": 1200
-          },
-          {
-            "type": "image",
-            "src": "img/archive/photo-series/photo-07.jpg",
-            "alt": "Product photo 7",
-            "caption": "Photo 07",
-            "frame": "landscape",
-            "width": 1800,
-            "height": 1200
           }
         ]
       }

--- a/public/index.html
+++ b/public/index.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Trijbs | UI/UX &amp; Web Designer</title>
-    <meta name="description" content="UI/UX and web designer crafting responsive websites, interface systems, e-commerce experiences, and creative digital products with strong visual direction.">
-    <meta name="keywords" content="ui ux designer, web designer, interface designer, responsive web design, portfolio, figma designer, freelance designer">
+    <title>Trijbs | Designer · Developer · Builder</title>
+    <meta name="description" content="Ruben Trijbels — designer, developer, and builder of interactive experiences, digital worlds, and visual systems. Based in the Netherlands.">
+    <meta name="keywords" content="designer developer, creative coding, interface design, web designer, portfolio, ruben trijbels, trijbs, interactive design, generative art">
     <meta name="robots" content="index, follow">
     <meta name="googlebot" content="index, follow">
     <meta name="author" content="Trijbs">
-    <meta property="og:title" content="Trijbs | UI/UX &amp; Web Designer">
-    <meta property="og:description" content="Designing modern websites and digital interfaces with a clear visual identity and strong user experience.">
+    <meta property="og:title" content="Trijbs | Designer · Developer · Builder">
+    <meta property="og:description" content="I work at the intersection of design and code — building interfaces, interactive experiments, and digital worlds from scratch.">
     <meta property="og:image" content="https://www.trijbsworld.nl/media/profile-hero-640.jpg">
     <meta property="og:url" content="https://www.trijbsworld.nl">
     <link rel="canonical" href="https://www.trijbsworld.nl">
@@ -24,32 +24,33 @@
         href="/media/profile-hero-640.jpg"
         imagesrcset="/media/profile-hero-320.jpg 320w, /media/profile-hero-480.jpg 480w, /media/profile-hero-640.jpg 640w"
         imagesizes="(max-width: 767px) calc(100vw - 2rem), 160px">
-    <link rel="stylesheet" href="css/styles.css?v=2.3.0">
+    <link rel="stylesheet" href="css/styles.css?v=3.0.0">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
         "@type": "Person",
-        "name": "Ruben Trijbs",
-        "jobTitle": "UI/UX & Web Designer",
+        "name": "Ruben Trijbels",
+        "jobTitle": "Designer & Developer",
         "url": "https://www.trijbsworld.nl",
         "email": "rbdegroot@gmail.com",
         "sameAs": [
             "https://github.com/trijbs",
-            "https://www.instagram.com/trijbsworld/"
+            "https://www.instagram.com/trijbsworld/",
+            "https://mvxworld.art"
         ],
         "knowsAbout": [
-            "Web Design",
             "Interface Design",
-            "UI/UX Design",
-            "Interaction Design",
-            "JavaScript",
+            "Creative Coding",
+            "Brand Identity",
+            "Web Development",
+            "Three.js",
+            "WebGL",
+            "React",
+            "Next.js",
             "Figma",
-            "Responsive Web Design",
-            "CSS",
-            "HTML",
-            "E-commerce Solutions"
+            "Generative Art"
         ],
-        "description": "UI/UX and web designer specializing in responsive websites, interface systems, e-commerce experiences, and visually driven digital products."
+        "description": "Designer and developer building interfaces, interactive experiments, and digital worlds from scratch."
     }
     </script>
 </head>
@@ -64,8 +65,8 @@
             <nav class="main-nav" id="primary-nav">
                 <ul>
                     <li><a href="#about">About</a></li>
-                    <li><a href="#skills">Skills</a></li>
-                    <li><a href="#projects">Projects</a></li>
+                    <li><a href="#skills">Practice</a></li>
+                    <li><a href="#projects">Work</a></li>
                     <li><a href="#contact">Contact</a></li>
                     <li><a href="/info.html">Info</a></li>
                 </ul>
@@ -81,22 +82,23 @@
     </header>
 
     <main>
-        <!-- Hero Section -->
+        <!-- ================================================
+             HERO
+        ================================================ -->
         <section id="hero" class="hero-section">
             <div class="container">
                 <div class="hero-grid">
                     <div class="hero-copy">
-                        <span class="eyebrow">UI/UX &amp; Web Designer</span>
-                        <h1 class="hero-title">UI/UX and web design with a clear visual point of view.</h1>
-                        <p class="hero-lead">I design responsive websites, interface systems, and digital experiences that feel polished from the first screen.</p>
+                        <span class="eyebrow">Designer &middot; Developer &middot; Builder</span>
+                        <h1 class="hero-title">Making things that look right and feel earned.</h1>
+                        <p class="hero-lead">I work at the intersection of design and code &mdash; building interfaces, interactive experiments, and digital worlds from scratch. Based in the Netherlands.</p>
                         <div class="hero-actions">
                             <a href="#projects" class="btn btn-primary">Selected Work</a>
-                            <a href="#skills" class="btn btn-secondary">Process</a>
+                            <a href="#about" class="btn btn-secondary">How I think</a>
                         </div>
-                        <div class="hero-signals" aria-label="Key strengths">
-                            <span>Web Design</span>
-                            <span>UI Systems</span>
-                            <span>Responsive Build</span>
+                        <div class="currently-block">
+                            <span class="currently-label">currently</span>
+                            building <a href="https://mvxworld.art" target="_blank" rel="noopener noreferrer"><strong>mvxworld.art</strong></a> &middot; shipping <strong>KAAR</strong> &middot; thinking about <strong>worlds</strong>
                         </div>
                     </div>
                     <div class="hero-stage">
@@ -122,15 +124,15 @@
                                     decoding="async">
                             </picture>
                             <div class="portrait-copy">
-                                <span class="mini-label">About Ruben</span>
-                                <p>Based in the Netherlands, focused on design-led websites and visually clear digital work.</p>
+                                <span class="mini-label">Ruben Trijbels</span>
+                                <p>NL-based. Design-led. Always building something.</p>
                             </div>
                         </aside>
                         <div class="hero-stage-panel hero-summary-panel">
                             <article class="stage-main-card">
-                                <span class="mini-label">Best fit</span>
-                                <h2>Landing pages, portfolios, and e-commerce concepts.</h2>
-                                <p>Clear hierarchy, cleaner interactions, and a design-to-development workflow that stays close to the original idea.</p>
+                                <span class="mini-label">The practice</span>
+                                <h2>Interface design, creative coding, and world-building as one gesture.</h2>
+                                <p>I don&apos;t separate design from development. The best work happens when both inform each other from the start.</p>
                             </article>
                         </div>
                     </div>
@@ -138,180 +140,159 @@
             </div>
         </section>
 
-        <!-- About Section -->
+        <!-- ================================================
+             ABOUT
+        ================================================ -->
         <section id="about" class="about-section">
             <div class="container">
                 <div class="section-header section-header-left">
-                    <span class="section-tag">Design Perspective</span>
-                    <h2 class="section-title">Work that looks intentional before you explain it.</h2>
-                    <p class="section-description">My portfolio is built around the kind of projects where layout, hierarchy, and user experience need to carry the first impression. I care about how a screen feels, how fast it reads, and how naturally it guides people forward.</p>
+                    <span class="section-tag">The Practice</span>
+                    <h2 class="section-title">Design and code are the same gesture, just different tools.</h2>
+                    <p class="section-description">I&apos;m a designer and developer who builds from first principles. The portfolio spans interactive experiences, brand identities, mobile apps, full-stack builds, and automated systems.</p>
                 </div>
                 <div class="about-layout">
                     <div class="about-story">
-                        <p class="about-highlight">I work between visual design and front-end execution, which keeps the final website close to the original concept.</p>
-                        <p>That means I am not only thinking about aesthetics. I am thinking about how navigation behaves, how components scale, how sections create momentum, and how a design system stays consistent across desktop and mobile.</p>
+                        <p class="about-highlight">The most interesting problems live between disciplines &mdash; where a visual decision is also a technical one, and the line between designer and engineer stops mattering.</p>
+                        <p>I started with graphic design, moved into front-end, and kept expanding from there. Today I build interactive experiences with Three.js and WebGL, design visual systems in Figma, develop full-stack apps with React and Next.js, and build automated tools when something should exist and doesn&apos;t yet. I also run a separate creative universe at <a href="https://mvxworld.art" target="_blank" rel="noopener noreferrer">mvxworld.art</a> &mdash; a personal identity hub I treat as a living archive and design experiment.</p>
+                        <p>What drives me is originality. Work that couldn&apos;t belong to anyone else. Work that has a point of view before it needs an explanation.</p>
                     </div>
                     <div class="principles-grid">
                         <article class="principle-card">
                             <span class="mini-label">01</span>
-                            <h3>Visual clarity</h3>
-                            <p>Strong typography, calm spacing, and contrast that lets the message land quickly.</p>
+                            <h3>First principles</h3>
+                            <p>I prefer building from scratch over assembling templates. Understanding the why makes every decision sharper.</p>
                         </article>
                         <article class="principle-card">
                             <span class="mini-label">02</span>
-                            <h3>User flow</h3>
-                            <p>Interfaces that guide visitors naturally instead of making them search for the next step.</p>
+                            <h3>Design close to code</h3>
+                            <p>Design decisions made without understanding the implementation rarely survive contact with reality. I close that gap by working both sides.</p>
                         </article>
                         <article class="principle-card">
                             <span class="mini-label">03</span>
-                            <h3>Responsive finish</h3>
-                            <p>Design decisions that stay sharp across screen sizes and feel built, not just mocked up.</p>
+                            <h3>Originality over optimization</h3>
+                            <p>A portfolio should have a point of view. Work that could belong to anyone isn&apos;t worth making. The interesting stuff lives past the generic solution.</p>
                         </article>
                     </div>
                 </div>
             </div>
         </section>
 
-        <!-- Skills Section -->
+        <!-- ================================================
+             PRACTICE (formerly Skills)
+        ================================================ -->
         <section id="skills" class="skills-section">
             <div class="container">
                 <div class="section-header">
-                    <span class="section-tag">Workflow &amp; Toolkit</span>
-                    <h2 class="section-title">How I approach UI/UX<br>and web design</h2>
-                    <p class="section-description">I focus on the parts of a project that shape how professional and usable it feels: visual systems, layout rhythm, interaction cues, and a clean handoff into code.</p>
+                    <span class="section-tag">Disciplines</span>
+                    <h2 class="section-title">How I work<br>and what I build</h2>
+                    <p class="section-description">I move across design and development depending on what the work needs. Most of my best projects live at the boundary between both.</p>
                 </div>
-                
-                <div class="skills-container">
-                    <div class="technical-skills">
-                        <h3>Core Design Strengths</h3>
-                        <div class="skill-item">
-                            <div class="skill-info">
-                                <span>UI Design</span>
-                                <span>92%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-progress="92"></div>
-                            </div>
+
+                <div class="practice-grid">
+                    <article class="practice-card">
+                        <span class="practice-number">01</span>
+                        <h3>Interface Design</h3>
+                        <p>Visual systems, UI components, typography hierarchy, responsive layouts, and design-to-development handoff. Figma-first, then close to the browser.</p>
+                        <div class="practice-tags">
+                            <span>Figma</span>
+                            <span>UI Systems</span>
+                            <span>Prototyping</span>
+                            <span>Design Tokens</span>
                         </div>
-                        <div class="skill-item">
-                            <div class="skill-info">
-                                <span>Responsive Web Design</span>
-                                <span>90%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-progress="90"></div>
-                            </div>
+                    </article>
+                    <article class="practice-card">
+                        <span class="practice-number">02</span>
+                        <h3>Creative Coding</h3>
+                        <p>Interactive web experiences, WebGL, generative visuals, audio-reactive interfaces. The space where code becomes a design medium rather than just an output.</p>
+                        <div class="practice-tags">
+                            <span>Three.js</span>
+                            <span>WebGL</span>
+                            <span>Canvas API</span>
+                            <span>React</span>
                         </div>
-                        <div class="skill-item">
-                            <div class="skill-info">
-                                <span>UX Structure</span>
-                                <span>86%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-progress="86"></div>
-                            </div>
+                    </article>
+                    <article class="practice-card">
+                        <span class="practice-number">03</span>
+                        <h3>Brand &amp; Identity</h3>
+                        <p>Visual identity systems, campaign design, exhibition concepts, motion. Making a brand feel consistent and intentional across every format and touchpoint.</p>
+                        <div class="practice-tags">
+                            <span>Identity Systems</span>
+                            <span>Print</span>
+                            <span>Motion</span>
+                            <span>Social Campaigns</span>
                         </div>
-                        <div class="skill-item">
-                            <div class="skill-info">
-                                <span>Prototyping</span>
-                                <span>84%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-progress="84"></div>
-                            </div>
+                    </article>
+                    <article class="practice-card">
+                        <span class="practice-number">04</span>
+                        <h3>Build &amp; Automate</h3>
+                        <p>Full-stack apps, mobile prototypes, bots, and tools. When something should exist and doesn&apos;t &mdash; I build it. Shipping counts as much as designing.</p>
+                        <div class="practice-tags">
+                            <span>Next.js</span>
+                            <span>TypeScript</span>
+                            <span>Python</span>
+                            <span>React Native</span>
                         </div>
-                        <div class="skill-item">
-                            <div class="skill-info">
-                                <span>Design-to-Development</span>
-                                <span>88%</span>
-                            </div>
-                            <div class="skill-bar">
-                                <div class="skill-progress" data-progress="88"></div>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <div class="creative-capabilities">
-                        <h3>Design Workflow</h3>
-                        <div class="workflow-list">
-                            <article class="workflow-step">
-                                <span class="mini-label">Discover</span>
-                                <p>Understand the brand, audience, and what the page needs to communicate first.</p>
-                            </article>
-                            <article class="workflow-step">
-                                <span class="mini-label">Structure</span>
-                                <p>Build hierarchy, layout rhythm, and clear page sections before adding polish.</p>
-                            </article>
-                            <article class="workflow-step">
-                                <span class="mini-label">Refine</span>
-                                <p>Develop the visual language with typography, color, components, and interaction details.</p>
-                            </article>
-                            <article class="workflow-step">
-                                <span class="mini-label">Launch</span>
-                                <p>Translate the design into responsive front-end work with consistent spacing and behavior.</p>
-                            </article>
-                        </div>
-                    </div>
+                    </article>
                 </div>
-                
+
                 <div class="toolbelt-panel">
                     <div class="toolbelt-copy">
-                        <span class="mini-label">Tools &amp; Outputs</span>
-                        <h3>What I usually deliver in a design-led project</h3>
-                        <p>Wireframes, interface concepts, component thinking, responsive layouts, Figma-based visuals, and production-ready front-end details.</p>
+                        <span class="mini-label">Stack</span>
+                        <h3>The usual tools</h3>
+                        <p>Figma &middot; HTML &amp; CSS &middot; JavaScript &middot; TypeScript &middot; React &middot; Next.js &middot; Three.js &middot; Node.js &middot; Python &middot; Supabase &middot; Vercel &middot; Git</p>
                     </div>
                     <div class="capabilities-grid designer-grid">
                         <div class="capability-item">
                             <i data-feather="pen-tool"></i>
-                            <span>Figma Concepts</span>
-                        </div>
-                        <div class="capability-item">
-                            <i data-feather="grid"></i>
-                            <span>Layout Systems</span>
-                        </div>
-                        <div class="capability-item">
-                            <i data-feather="smartphone"></i>
-                            <span>Mobile UX</span>
-                        </div>
-                        <div class="capability-item">
-                            <i data-feather="shopping-bag"></i>
-                            <span>E-commerce UI</span>
-                        </div>
-                        <div class="capability-item">
-                            <i data-feather="pen-tool"></i>
-                            <span>Visual Direction</span>
+                            <span>Figma Design</span>
                         </div>
                         <div class="capability-item">
                             <i data-feather="code"></i>
                             <span>Front-end Build</span>
                         </div>
+                        <div class="capability-item">
+                            <i data-feather="cpu"></i>
+                            <span>Creative Coding</span>
+                        </div>
+                        <div class="capability-item">
+                            <i data-feather="smartphone"></i>
+                            <span>Mobile Apps</span>
+                        </div>
+                        <div class="capability-item">
+                            <i data-feather="globe"></i>
+                            <span>World-building</span>
+                        </div>
+                        <div class="capability-item">
+                            <i data-feather="zap"></i>
+                            <span>Automation</span>
+                        </div>
                     </div>
                 </div>
             </div>
         </section>
 
-        <!-- Projects Section -->
+        <!-- ================================================
+             PROJECTS
+        ================================================ -->
         <section id="projects" class="projects-section">
             <div class="container">
                 <div class="section-header">
                     <span class="section-tag">Selected Work</span>
-                    <h2 class="section-title">Projects that show<br>interface thinking</h2>
-                    <p class="section-description">These projects show how I work across interfaces, visual systems, campaigns, and archive pieces, with older work grouped into clearer collections so the portfolio stays easy to read.</p>
+                    <h2 class="section-title">Things I&apos;ve built<br>that I&apos;m proud of</h2>
+                    <p class="section-description">A curated selection. I&apos;ve removed anything that doesn&apos;t hold up &mdash; what&apos;s left is the work that has a clear reason to be here.</p>
                 </div>
-                
+
                 <div class="project-filters">
-                    <button class="filter-btn active" data-filter="all">All Projects</button>
-                    <button class="filter-btn" data-filter="uiux">UI / UX</button>
-                    <button class="filter-btn" data-filter="campaign">Campaign</button>
-                    <button class="filter-btn" data-filter="editorial">Editorial</button>
-                    <button class="filter-btn" data-filter="print">Print</button>
-                    <button class="filter-btn" data-filter="motion">Motion</button>
-                    <button class="filter-btn" data-filter="photo">Photo</button>
+                    <button class="filter-btn active" data-filter="all">All</button>
+                    <button class="filter-btn" data-filter="interactive">Interactive</button>
+                    <button class="filter-btn" data-filter="design">Design</button>
+                    <button class="filter-btn" data-filter="build">Build</button>
                 </div>
-                
+
                 <div class="projects-grid">
-                    <!-- Featured Project 1 -->
-                    <div class="project-card featured" data-category="uiux motion">
+
+                    <!-- ── URBAN UNLEASHED – Featured ── -->
+                    <div class="project-card featured" data-category="interactive build">
                         <div class="project-image">
                             <picture>
                                 <source
@@ -326,7 +307,7 @@
                                     src="media/urban-unleashed-cover-768.jpg"
                                     srcset="media/urban-unleashed-cover-480.jpg 480w, media/urban-unleashed-cover-768.jpg 768w, media/urban-unleashed-cover-1200.jpg 1200w"
                                     sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px"
-                                    alt="Urban Unleashed - Interactive Homescreen Interface"
+                                    alt="Urban Unleashed - Immersive landing page with Three.js and WebGL"
                                     width="1800"
                                     height="854"
                                     loading="lazy"
@@ -346,118 +327,47 @@
                             </div>
                         </div>
                         <div class="project-content">
-                            <p class="project-kicker">Interactive website concept</p>
+                            <p class="project-kicker">Immersive landing experience</p>
                             <div class="project-header">
                                 <h3>Urban Unleashed</h3>
                                 <div class="project-status">
                                     <span class="status-badge featured">Featured</span>
                                 </div>
                             </div>
-                            <p>An immersive landing experience where the interface acts as part of the brand. The concept combines bold visuals, intuitive controls, and a strong first-screen composition.</p>
+                            <p>A landing page where the interface is the brand. Bold visuals, WebGL motion, and a strong first-screen composition that holds up across every screen size.</p>
                             <div class="project-tags">
                                 <span class="tag">Next.js</span>
                                 <span class="tag">Three.js</span>
                                 <span class="tag">WebGL</span>
                                 <span class="tag">Generative Art</span>
                             </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="eye"></i>
-                                    <span>2.5k views</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="star"></i>
-                                    <span>4.8/5 rating</span>
-                                </div>
-                            </div>
                         </div>
                     </div>
-                    
-                    <!-- Figma Design Project -->
-                    <div class="project-card figma-project" data-category="uiux">
+
+                    <!-- ── MVXWORLD – Featured, NEW ── -->
+                    <div class="project-card featured code-preview-card" data-category="interactive design build" style="--preview-bg:#0a0a09; --preview-accent:#c8ff00;">
                         <div class="project-image">
-                            <div class="figma-preview">
-                                <div class="figma-icon">
-                                    <svg width="60" height="60" viewBox="0 0 38 57" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                        <path d="M19 28.5C19 23.2533 23.2533 19 28.5 19C33.7467 19 38 23.2533 38 28.5C38 33.7467 33.7467 38 28.5 38C23.2533 38 19 33.7467 19 28.5Z" fill="#1ABCFE"/>
-                                        <path d="M0 47.5C0 42.2533 4.25329 38 9.5 38H19V47.5C19 52.7467 14.7467 57 9.5 57C4.25329 57 0 52.7467 0 47.5Z" fill="#0ACF83"/>
-                                        <path d="M19 0V19H28.5C33.7467 19 38 14.7467 38 9.5C38 4.25329 33.7467 0 28.5 0H19Z" fill="#FF7262"/>
-                                        <path d="M0 9.5C0 14.7467 4.25329 19 9.5 19H19V0H9.5C4.25329 0 0 4.25329 0 9.5Z" fill="#F24E1E"/>
-                                        <path d="M0 28.5C0 33.7467 4.25329 38 9.5 38H19V19H9.5C4.25329 19 0 23.2533 0 28.5Z" fill="#A259FF"/>
-                                    </svg>
+                            <div class="code-preview" aria-hidden="true">
+                                <div class="code-preview-inner">
+                                    <div class="code-preview-sigil">MVX</div>
+                                    <div class="code-preview-meta">
+                                        <span class="code-preview-label">personal universe</span>
+                                        <span class="code-preview-url">mvxworld.art</span>
+                                    </div>
+                                    <div class="code-preview-lines">
+                                        <div class="cpl"><span class="cpl-k">building</span> <span class="cpl-v">the room</span></div>
+                                        <div class="cpl"><span class="cpl-k">transmission</span> <span class="cpl-v">002 / live</span></div>
+                                        <div class="cpl"><span class="cpl-k">status</span> <span class="cpl-v cpl-active">expanding ▸</span></div>
+                                    </div>
                                 </div>
-                                <p class="figma-label">Figma Design</p>
                             </div>
                             <div class="project-overlay">
                                 <div class="project-actions">
-                                    <button class="btn btn-primary figma-view" data-figma-url="https://www.figma.com/design/URqiY9oVCADc202Wqxb33c/opdracht-10?node-id=8-1346n" data-title="Opdracht 10 - Design Project">
-                                        <i data-feather="pen-tool"></i>
-                                        View in Figma
-                                    </button>
-                                    <button class="btn btn-secondary figma-embed" data-figma-embed="https://embed.figma.com/design/URqiY9oVCADc202Wqxb33c/opdracht-10?node-id=8-1346&embed-host=share" data-title="Opdracht 10 - Design Project">
-                                        <i data-feather="eye"></i>
-                                        Preview
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="project-content">
-                            <p class="project-kicker">Figma case study</p>
-                            <div class="project-header">
-                                <h3>E-commerce UI Concept</h3>
-                                <div class="project-status">
-                                    <span class="status-badge design">Figma</span>
-                                </div>
-                            </div>
-                            <p>A focused UI/UX concept for an e-commerce experience with reusable components, clearer hierarchy, and prototype-driven exploration in Figma.</p>
-                            <div class="project-tags">
-                                <span class="tag">Figma</span>
-                                <span class="tag">UI/UX</span>
-                                <span class="tag">Design</span>
-                                <span class="tag">Prototype</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="layers"></i>
-                                    <span>Design System</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="pen-tool"></i>
-                                    <span>Design System</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- Project 2 -->
-                    <div class="project-card" data-category="uiux">
-                        <div class="project-image">
-                            <picture>
-                                <source
-                                    type="image/avif"
-                                    srcset="media/Webshop-480.avif 480w, media/Webshop-768.avif 768w, media/Webshop-1000.avif 1000w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px">
-                                <source
-                                    type="image/webp"
-                                    srcset="media/Webshop-480.webp 480w, media/Webshop-768.webp 768w, media/Webshop-1000.webp 1000w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px">
-                                <img
-                                    src="media/Webshop-768.webp"
-                                    srcset="media/Webshop-480.webp 480w, media/Webshop-768.webp 768w, media/Webshop-1000.webp 1000w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px"
-                                    alt="Modern E-commerce Platform"
-                                    width="1000"
-                                    height="510"
-                                    loading="lazy"
-                                    decoding="async">
-                            </picture>
-                            <div class="project-overlay">
-                                <div class="project-actions">
-                                    <button class="btn btn-primary live-demo" data-url="https://trijbs.eu/Webshop/" data-title="E-commerce Platform">
+                                    <button class="btn btn-primary live-demo" data-url="https://mvxworld.art" data-title="mvxworld.art">
                                         <i data-feather="external-link"></i>
-                                        Live Demo
+                                        Visit Site
                                     </button>
-                                    <button class="btn btn-secondary view-details" data-project="webshop">
+                                    <button class="btn btn-secondary view-details" data-project="mvxworld">
                                         <i data-feather="info"></i>
                                         Details
                                     </button>
@@ -465,183 +375,25 @@
                             </div>
                         </div>
                         <div class="project-content">
-                            <p class="project-kicker">Conversion-focused webshop design</p>
+                            <p class="project-kicker">Personal identity hub &amp; living archive</p>
                             <div class="project-header">
-                                <h3>E-commerce Platform</h3>
-                            </div>
-                            <p>A webshop concept built around product visibility, CTA hierarchy, and a smoother shopping flow. The design balances usability, trust, and visual consistency.</p>
-                            <div class="project-tags">
-                                <span class="tag">React</span>
-                                <span class="tag">Node.js</span>
-                                <span class="tag">MongoDB</span>
-                                <span class="tag">Stripe API</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="shopping-cart"></i>
-                                    <span>E-commerce</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="users"></i>
-                                    <span>Multi-user</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Animated Infographic Video Project -->
-                    <div class="project-card video-project" data-category="motion campaign">
-                        <div class="project-image">
-                            <div class="video-preview">
-                                <span class="video-badge">Video</span>
-                                <picture>
-                                    <source
-                                        type="image/avif"
-                                        srcset="media/archive/infographic-poster-480.avif 480w, media/archive/infographic-poster-768.avif 768w, media/archive/infographic-poster-1200.avif 1200w"
-                                        sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px">
-                                    <source
-                                        type="image/webp"
-                                        srcset="media/archive/infographic-poster-480.webp 480w, media/archive/infographic-poster-768.webp 768w, media/archive/infographic-poster-1200.webp 1200w"
-                                        sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px">
-                                    <img
-                                        src="media/archive/infographic-poster-768.png"
-                                        srcset="media/archive/infographic-poster-480.png 480w, media/archive/infographic-poster-768.png 768w, media/archive/infographic-poster-1200.png 1200w"
-                                        sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px"
-                                        alt="Animated infographic preview"
-                                        width="1200"
-                                        height="675"
-                                        loading="lazy"
-                                        decoding="async">
-                                </picture>
-
-                                <div class="video-play-overlay">
-                                    <div class="play-icon">
-                                        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                            <path d="M8 5v14l11-7z"/>
-                                        </svg>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="project-overlay">
-                                <div class="project-actions">
-                                    <button class="btn btn-primary video-play" data-video="videos/archive/infographic.mp4" data-title="Animated Infographic">
-                                        <i data-feather="play-circle"></i>
-                                        Play Video
-                                    </button>
-                                    <button class="btn btn-secondary view-details" data-project="motion-design-studies">
-                                        <i data-feather="layers"></i>
-                                        View Collection
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="project-content">
-                            <p class="project-kicker">Motion and information design</p>
-                            <div class="project-header">
-                                <h3>Animated Infographic</h3>
+                                <h3>mvxworld.art</h3>
                                 <div class="project-status">
-                                    <span class="status-badge video">Video</span>
+                                    <span class="status-badge new">Live</span>
                                 </div>
                             </div>
-                            <p>A motion-led design piece that turns complex information into a visual narrative, with pacing, contrast, and composition driving readability.</p>
+                            <p>A personal universe built as a multi-page dark archive. Each page is a room discovered, not a section bolted on. Custom design system, transmissions engine, and lore &mdash; all in vanilla HTML, CSS, and JS.</p>
                             <div class="project-tags">
-                                <span class="tag">Motion Design</span>
-                                <span class="tag">Infographic</span>
-                                <span class="tag">Animation</span>
-                                <span class="tag">Video</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="film"></i>
-                                    <span>MP4 Video</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="clock"></i>
-                                    <span>HD Quality</span>
-                                </div>
+                                <span class="tag">World-building</span>
+                                <span class="tag">Vanilla HTML/CSS</span>
+                                <span class="tag">Design System</span>
+                                <span class="tag">Identity</span>
                             </div>
                         </div>
                     </div>
 
-                    <div class="project-card video-project" data-category="motion">
-                        <div class="project-image">
-                            <div class="video-preview">
-                                <span class="video-badge">Video</span>
-                                <picture>
-                                    <source
-                                        type="image/avif"
-                                        srcset="media/archive/video-namaak-editen-poster-480.avif 480w, media/archive/video-namaak-editen-poster-768.avif 768w, media/archive/video-namaak-editen-poster-1200.avif 1200w"
-                                        sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px">
-                                    <source
-                                        type="image/webp"
-                                        srcset="media/archive/video-namaak-editen-poster-480.webp 480w, media/archive/video-namaak-editen-poster-768.webp 768w, media/archive/video-namaak-editen-poster-1200.webp 1200w"
-                                        sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px">
-                                    <img
-                                        src="media/archive/video-namaak-editen-poster-768.png"
-                                        srcset="media/archive/video-namaak-editen-poster-480.png 480w, media/archive/video-namaak-editen-poster-768.png 768w, media/archive/video-namaak-editen-poster-1200.png 1200w"
-                                        sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px"
-                                        alt="Video editing remake preview"
-                                        width="1600"
-                                        height="720"
-                                        loading="lazy"
-                                        decoding="async">
-                                </picture>
-
-                                <div class="video-play-overlay">
-                                    <div class="play-icon">
-                                        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                            <path d="M8 5v14l11-7z"/>
-                                        </svg>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="project-overlay">
-                                <div class="project-actions">
-                                    <button class="btn btn-primary video-play" data-video="videos/archive/video-namaak-editen.mp4" data-title="Video Editing Remake">
-                                        <i data-feather="play-circle"></i>
-                                        Play Video
-                                    </button>
-                                    <button class="btn btn-secondary view-details" data-project="video-editing-remake">
-                                        <i data-feather="film"></i>
-                                        Details
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="project-content">
-                            <p class="project-kicker">Editing remake</p>
-                            <div class="project-header">
-                                <h3>Video Editing Remake</h3>
-                                <div class="project-status">
-                                    <span class="status-badge video">Video</span>
-                                </div>
-                            </div>
-                            <p>A split-screen remake focused on timing, pacing, and cleaner transitions.</p>
-                            <div class="project-tags">
-                                <span class="tag">Video Editing</span>
-                                <span class="tag">Pacing</span>
-                                <span class="tag">Transitions</span>
-                                <span class="tag">Motion Study</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="clock"></i>
-                                    <span>50.9 second edit</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="sliders"></i>
-                                    <span>Side-by-side remake</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Project 3 -->
-                    <div class="project-card popfusion-card" data-category="uiux motion">
+                    <!-- ── POPFUSION – Featured ── -->
+                    <div class="project-card featured popfusion-card" data-category="interactive build">
                         <div class="project-image">
                             <picture>
                                 <source
@@ -656,7 +408,7 @@
                                     src="media/popfusion-cover-768.jpg"
                                     srcset="media/popfusion-cover-480.jpg 480w, media/popfusion-cover-768.jpg 768w, media/popfusion-cover-1200.jpg 1200w"
                                     sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px"
-                                    alt="PopFusion - Music Visualizer"
+                                    alt="PopFusion - Audio-reactive music visualizer"
                                     width="1800"
                                     height="1125"
                                     loading="lazy"
@@ -676,38 +428,174 @@
                             </div>
                         </div>
                         <div class="project-content">
-                            <p class="project-kicker">Experimental interface</p>
+                            <p class="project-kicker">Audio-reactive web experience</p>
                             <div class="project-header">
                                 <h3>PopFusion</h3>
                                 <div class="project-status">
-                                    <span class="status-badge new">New</span>
+                                    <span class="status-badge featured">Featured</span>
                                 </div>
                             </div>
-                            <p>An audio-reactive web experience focused on atmosphere, motion, and expressive interface behavior. Designed to feel playful without losing clarity.</p>
+                            <p>Sound made visual. An audio-reactive interface where motion and atmosphere respond to music in real time. Expressive without losing clarity &mdash; that was the entire design problem.</p>
                             <div class="project-tags">
-                                <span class="tag">React</span>
                                 <span class="tag">Web Audio API</span>
                                 <span class="tag">Canvas</span>
-                                <span class="tag">Music</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="eye"></i>
-                                    <span>1.8k views</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="heart"></i>
-                                    <span>156 likes</span>
-                                </div>
+                                <span class="tag">React</span>
+                                <span class="tag">Creative Coding</span>
                             </div>
                         </div>
                     </div>
 
-                    <div class="projects-group-divider" aria-hidden="true">
-                        <span class="divider-label">Archived Collections</span>
+                    <!-- ── KAAR – NEW ── -->
+                    <div class="project-card code-preview-card" data-category="build interactive" style="--preview-bg:#0f0a1a; --preview-accent:#fa709a;">
+                        <div class="project-image">
+                            <div class="code-preview" aria-hidden="true">
+                                <div class="code-preview-inner">
+                                    <div class="code-preview-sigil" style="font-size:2.2rem; letter-spacing:0.15em;">KAAR</div>
+                                    <div class="code-preview-meta">
+                                        <span class="code-preview-label">multiplayer touch arena</span>
+                                        <span class="code-preview-url">React Native / Expo</span>
+                                    </div>
+                                    <div class="code-preview-lines">
+                                        <div class="cpl"><span class="cpl-k">players</span> <span class="cpl-v">1 &rarr; 8 fingers</span></div>
+                                        <div class="cpl"><span class="cpl-k">modes</span> <span class="cpl-v">winner · teams · chaos</span></div>
+                                        <div class="cpl"><span class="cpl-k">reveal</span> <span class="cpl-v cpl-active">suspense first ▸</span></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="project-overlay">
+                                <div class="project-actions">
+                                    <button class="btn btn-primary live-demo" data-url="https://github.com/Trijbs/KAAR" data-title="KAAR">
+                                        <i data-feather="github"></i>
+                                        View on GitHub
+                                    </button>
+                                    <button class="btn btn-secondary view-details" data-project="kaar">
+                                        <i data-feather="info"></i>
+                                        Details
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="project-content">
+                            <p class="project-kicker">Mobile party app &mdash; React Native</p>
+                            <div class="project-header">
+                                <h3>KAAR</h3>
+                                <div class="project-status">
+                                    <span class="status-badge new">New</span>
+                                </div>
+                            </div>
+                            <p>A multi-touch party app where everyone places a finger, the room locks in, and a dramatic reveal picks the outcome. Built in Expo React Native with a full theme system, haptics, and game logic designed from scratch.</p>
+                            <div class="project-tags">
+                                <span class="tag">React Native</span>
+                                <span class="tag">Expo</span>
+                                <span class="tag">TypeScript</span>
+                                <span class="tag">Product Design</span>
+                            </div>
+                        </div>
                     </div>
 
-                    <div class="project-card archive-card" data-category="campaign editorial print">
+                    <!-- ── WEEKPLANNER APP – NEW ── -->
+                    <div class="project-card code-preview-card" data-category="build" style="--preview-bg:#0d1117; --preview-accent:#4facfe;">
+                        <div class="project-image">
+                            <div class="code-preview" aria-hidden="true">
+                                <div class="code-preview-inner">
+                                    <div class="code-preview-sigil" style="font-size:1.1rem; letter-spacing:0.05em; font-family:var(--font-body,sans-serif); font-weight:700;">week<br>planner</div>
+                                    <div class="code-preview-meta">
+                                        <span class="code-preview-label">full-stack planning app</span>
+                                        <span class="code-preview-url">weekplanner.trijbsworld.nl</span>
+                                    </div>
+                                    <div class="code-preview-lines">
+                                        <div class="cpl"><span class="cpl-k">stack</span> <span class="cpl-v">Next.js + Supabase</span></div>
+                                        <div class="cpl"><span class="cpl-k">features</span> <span class="cpl-v">blocks · threads · sync</span></div>
+                                        <div class="cpl"><span class="cpl-k">status</span> <span class="cpl-v cpl-active">live ▸</span></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="project-overlay">
+                                <div class="project-actions">
+                                    <button class="btn btn-primary live-demo" data-url="https://weekplanner.trijbsworld.nl" data-title="WeekPlanner App">
+                                        <i data-feather="external-link"></i>
+                                        Live App
+                                    </button>
+                                    <button class="btn btn-secondary view-details" data-project="weekplanner">
+                                        <i data-feather="info"></i>
+                                        Details
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="project-content">
+                            <p class="project-kicker">Full-stack productivity app</p>
+                            <div class="project-header">
+                                <h3>WeekPlanner</h3>
+                                <div class="project-status">
+                                    <span class="status-badge new">Live</span>
+                                </div>
+                            </div>
+                            <p>A structured week planner with hourly time blocks, assignees, thought threads, and real-time sync. Built with Next.js, TypeScript, and Supabase &mdash; including automated hourly cron syncing and a PWA setup.</p>
+                            <div class="project-tags">
+                                <span class="tag">Next.js</span>
+                                <span class="tag">TypeScript</span>
+                                <span class="tag">Supabase</span>
+                                <span class="tag">PWA</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- ── TAINMENT / BOT ECOSYSTEM – NEW ── -->
+                    <div class="project-card code-preview-card" data-category="build" style="--preview-bg:#0a1a0a; --preview-accent:#43e97b;">
+                        <div class="project-image">
+                            <div class="code-preview" aria-hidden="true">
+                                <div class="code-preview-inner">
+                                    <div class="code-preview-sigil" style="font-size:1.4rem; letter-spacing:0.1em;">tainment</div>
+                                    <div class="code-preview-meta">
+                                        <span class="code-preview-label">discord bot ecosystem</span>
+                                        <span class="code-preview-url">Python &amp; Node.js</span>
+                                    </div>
+                                    <div class="code-preview-lines">
+                                        <div class="cpl"><span class="cpl-k">features</span> <span class="cpl-v">casino · fishing · trivia</span></div>
+                                        <div class="cpl"><span class="cpl-k">stack</span> <span class="cpl-v">Python / discord.py</span></div>
+                                        <div class="cpl"><span class="cpl-k">status</span> <span class="cpl-v cpl-active">running ▸</span></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="project-overlay">
+                                <div class="project-actions">
+                                    <button class="btn btn-primary live-demo" data-url="https://github.com/Tribsy/tainment" data-title="Tainment Bot">
+                                        <i data-feather="github"></i>
+                                        View on GitHub
+                                    </button>
+                                    <button class="btn btn-secondary view-details" data-project="tainment">
+                                        <i data-feather="info"></i>
+                                        Details
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="project-content">
+                            <p class="project-kicker">Automation &amp; community tooling</p>
+                            <div class="project-header">
+                                <h3>Tainment</h3>
+                                <div class="project-status">
+                                    <span class="status-badge build">Build</span>
+                                </div>
+                            </div>
+                            <p>A Discord bot ecosystem with casino mechanics, fishing games, trivia, leaderboards, and subscription management. Built across two repos (Python and Node.js) &mdash; the kind of project you build because you want it to exist.</p>
+                            <div class="project-tags">
+                                <span class="tag">Python</span>
+                                <span class="tag">Node.js</span>
+                                <span class="tag">Discord API</span>
+                                <span class="tag">Automation</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- ── ARCHIVE DIVIDER ── -->
+                    <div class="projects-group-divider" aria-hidden="true">
+                        <span class="divider-label">Design Archive</span>
+                    </div>
+
+                    <!-- ── IRIS VAN HERPEN ── -->
+                    <div class="project-card archive-card" data-category="design">
                         <div class="project-image">
                             <picture>
                                 <source
@@ -722,7 +610,7 @@
                                     src="media/archive/iris-van-herpen/01_Artists_Impression_Expositie-768.jpg"
                                     srcset="media/archive/iris-van-herpen/01_Artists_Impression_Expositie-480.jpg 480w, media/archive/iris-van-herpen/01_Artists_Impression_Expositie-768.jpg 768w, media/archive/iris-van-herpen/01_Artists_Impression_Expositie-1200.jpg 1200w"
                                     sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px"
-                                    alt="Iris van Herpen exhibition concept render"
+                                    alt="Iris van Herpen Metamorfose exhibition identity"
                                     width="1312"
                                     height="736"
                                     loading="lazy"
@@ -738,96 +626,63 @@
                             </div>
                         </div>
                         <div class="project-content">
-                            <p class="project-kicker">Exhibition identity</p>
+                            <p class="project-kicker">Exhibition identity system</p>
                             <div class="project-header">
                                 <h3>Iris van Herpen Exhibition</h3>
                                 <div class="project-status">
                                     <span class="status-badge archive">Archive</span>
                                 </div>
                             </div>
-                            <p>A museum concept built around one fashion-led visual system, from posters and flyers to social formats.</p>
+                            <p>A museum identity concept for <em>Metamorfose</em> &mdash; one visual language across posters, flyers, editorial ads, and social formats. Three distinct poster directions, one consistent world.</p>
                             <div class="project-tags">
                                 <span class="tag">Exhibition Design</span>
                                 <span class="tag">Poster Series</span>
-                                <span class="tag">Social Assets</span>
                                 <span class="tag">Art Direction</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="image"></i>
-                                    <span>9-piece campaign set</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="briefcase"></i>
-                                    <span>Museum concept</span>
-                                </div>
                             </div>
                         </div>
                     </div>
 
-                    <div class="project-card archive-card" data-category="editorial print">
+                    <!-- ── HIDDEN REALMS FEST ── -->
+                    <div class="project-card archive-card" data-category="design interactive">
                         <div class="project-image">
                             <picture>
-                                <source
-                                    type="image/avif"
-                                    srcset="media/archive/spread-week-3/spread-week-3-01-360.avif 360w, media/archive/spread-week-3/spread-week-3-01-640.avif 640w, media/archive/spread-week-3/spread-week-3-01-960.avif 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px">
-                                <source
-                                    type="image/webp"
-                                    srcset="media/archive/spread-week-3/spread-week-3-01-360.webp 360w, media/archive/spread-week-3/spread-week-3-01-640.webp 640w, media/archive/spread-week-3/spread-week-3-01-960.webp 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px">
+                                <source type="image/webp" srcset="media/archive/festival-identity/moodboard-480.webp 480w, media/archive/festival-identity/moodboard-768.webp 768w" sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px">
                                 <img
-                                    src="media/archive/spread-week-3/spread-week-3-01-640.png"
-                                    srcset="media/archive/spread-week-3/spread-week-3-01-360.png 360w, media/archive/spread-week-3/spread-week-3-01-640.png 640w, media/archive/spread-week-3/spread-week-3-01-960.png 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px"
-                                    alt="Figurative photo editorial spread cover"
-                                    width="1275"
-                                    height="1768"
+                                    src="media/archive/festival-identity/moodboard.jpg"
+                                    alt="Hidden Realms Fest identity moodboard"
+                                    width="1800"
+                                    height="1273"
                                     loading="lazy"
                                     decoding="async">
                             </picture>
                             <div class="project-overlay">
                                 <div class="project-actions">
-                                    <button class="btn btn-primary view-details" data-project="figurative-photo-spread">
-                                        <i data-feather="book-open"></i>
-                                        Open Spread
+                                    <button class="btn btn-primary view-details" data-project="hidden-realms-fest">
+                                        <i data-feather="layers"></i>
+                                        View Collection
                                     </button>
-                                    <a href="files/spread-week-3.pdf" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
-                                        <i data-feather="file-text"></i>
-                                        Open PDF
-                                    </a>
                                 </div>
                             </div>
                         </div>
                         <div class="project-content">
-                            <p class="project-kicker">Editorial spread study</p>
+                            <p class="project-kicker">Festival identity &amp; motion</p>
                             <div class="project-header">
-                                <h3>Figurative Photo Spread</h3>
+                                <h3>Hidden Realms Fest</h3>
                                 <div class="project-status">
                                     <span class="status-badge archive">Archive</span>
                                 </div>
                             </div>
-                            <p>A four-page editorial layout that pairs photography theory with a tighter image-led spread system.</p>
+                            <p>Identity planning, social launch assets, and motion teasers for a festival brand. The moodboard and style sheet define the world before the launch assets extend it into motion and social formats.</p>
                             <div class="project-tags">
-                                <span class="tag">Editorial Design</span>
-                                <span class="tag">Typography</span>
-                                <span class="tag">Spread Layout</span>
-                                <span class="tag">Print Study</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="book-open"></i>
-                                    <span>4-page sequence</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="grid"></i>
-                                    <span>Layout + image study</span>
-                                </div>
+                                <span class="tag">Festival Branding</span>
+                                <span class="tag">Motion</span>
+                                <span class="tag">Social Campaign</span>
                             </div>
                         </div>
                     </div>
 
-                    <div class="project-card archive-card" data-category="uiux campaign">
+                    <!-- ── NORTH FACE CAMPAIGN ── -->
+                    <div class="project-card archive-card" data-category="design">
                         <div class="project-image">
                             <picture>
                                 <source
@@ -842,7 +697,7 @@
                                     src="media/archive/northface/mobile-01-480.jpg"
                                     srcset="media/archive/northface/mobile-01-360.jpg 360w, media/archive/northface/mobile-01-480.jpg 480w, media/archive/northface/mobile-01-615.jpg 615w"
                                     sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px"
-                                    alt="The North Face campaign homescreen concept"
+                                    alt="The North Face digital campaign mobile screens"
                                     width="615"
                                     height="1600"
                                     loading="lazy"
@@ -858,543 +713,43 @@
                             </div>
                         </div>
                         <div class="project-content">
-                            <p class="project-kicker">Retail interface campaign</p>
+                            <p class="project-kicker">Retail UI campaign</p>
                             <div class="project-header">
                                 <h3>The North Face Digital Campaign</h3>
                                 <div class="project-status">
                                     <span class="status-badge archive">Archive</span>
                                 </div>
                             </div>
-                            <p>A focused campaign set built around mobile product screens and a matching CRM email layout, with the strongest work centered on retail hierarchy and campaign clarity.</p>
+                            <p>Mobile-first campaign screens and a CRM email layout built around retail hierarchy, product promotion, and campaign clarity. Six mobile screens, one consistent brand direction.</p>
                             <div class="project-tags">
-                                <span class="tag">UI Design</span>
-                                <span class="tag">Mobile Screens</span>
-                                <span class="tag">CRM Email</span>
-                                <span class="tag">Campaign Layout</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="layers"></i>
-                                    <span>Mobile-first campaign</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="smartphone"></i>
-                                    <span>Retail UI screens</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="project-card archive-card" data-category="campaign print">
-                        <div class="project-image">
-                            <picture>
-                                <source
-                                    type="image/avif"
-                                    srcset="media/archive/sire-diabetes/sire-diabetes-01-480.avif 480w, media/archive/sire-diabetes/sire-diabetes-01-768.avif 768w, media/archive/sire-diabetes/sire-diabetes-01-1200.avif 1200w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px">
-                                <source
-                                    type="image/webp"
-                                    srcset="media/archive/sire-diabetes/sire-diabetes-01-480.webp 480w, media/archive/sire-diabetes/sire-diabetes-01-768.webp 768w, media/archive/sire-diabetes/sire-diabetes-01-1200.webp 1200w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px">
-                                <img
-                                    src="media/archive/sire-diabetes/sire-diabetes-01-768.png"
-                                    srcset="media/archive/sire-diabetes/sire-diabetes-01-480.png 480w, media/archive/sire-diabetes/sire-diabetes-01-768.png 768w, media/archive/sire-diabetes/sire-diabetes-01-1200.png 1200w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px"
-                                    alt="SIRE diabetes awareness campaign spread"
-                                    width="1275"
-                                    height="924"
-                                    loading="lazy"
-                                    decoding="async">
-                            </picture>
-                            <div class="project-overlay">
-                                <div class="project-actions">
-                                    <button class="btn btn-primary view-details" data-project="sire-diabetes-campaign">
-                                        <i data-feather="layers"></i>
-                                        View Project
-                                    </button>
-                                    <a href="files/sire-diabetes.pdf" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
-                                        <i data-feather="file-text"></i>
-                                        Open PDF
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="project-content">
-                            <p class="project-kicker">Awareness campaign</p>
-                            <div class="project-header">
-                                <h3>SIRE Diabetes Campaign</h3>
-                                <div class="project-status">
-                                    <span class="status-badge archive">Archive</span>
-                                </div>
-                            </div>
-                            <p>A three-page print campaign that turns sugar and diabetes into a sharper public message.</p>
-                            <div class="project-tags">
+                                <span class="tag">Mobile UI</span>
                                 <span class="tag">Campaign Design</span>
-                                <span class="tag">Health Awareness</span>
-                                <span class="tag">Print Layout</span>
-                                <span class="tag">Typography</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="file-text"></i>
-                                    <span>3-page campaign</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="activity"></i>
-                                    <span>Public call to action</span>
-                                </div>
+                                <span class="tag">CRM Email</span>
                             </div>
                         </div>
                     </div>
 
-                    <div class="project-card archive-card" data-category="editorial print">
-                        <div class="project-image">
-                            <picture>
-                                <source
-                                    type="image/avif"
-                                    srcset="media/archive/editorial-trends/trends-01-360.avif 360w, media/archive/editorial-trends/trends-01-640.avif 640w, media/archive/editorial-trends/trends-01-960.avif 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px">
-                                <source
-                                    type="image/webp"
-                                    srcset="media/archive/editorial-trends/trends-01-360.webp 360w, media/archive/editorial-trends/trends-01-640.webp 640w, media/archive/editorial-trends/trends-01-960.webp 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px">
-                                <img
-                                    src="media/archive/editorial-trends/trends-01-640.jpg"
-                                    srcset="media/archive/editorial-trends/trends-01-360.jpg 360w, media/archive/editorial-trends/trends-01-640.jpg 640w, media/archive/editorial-trends/trends-01-960.jpg 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px"
-                                    alt="10 trends of graphic design editorial booklet"
-                                    width="1184"
-                                    height="1600"
-                                    loading="lazy"
-                                    decoding="async">
-                            </picture>
-                            <div class="project-overlay">
-                                <div class="project-actions">
-                                    <button class="btn btn-primary view-details" data-project="editorial-booklets">
-                                        <i data-feather="book-open"></i>
-                                        Open Booklets
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="project-content">
-                            <p class="project-kicker">Editorial sequence</p>
-                            <div class="project-header">
-                                <h3>Editorial Layout Collection</h3>
-                                <div class="project-status">
-                                    <span class="status-badge archive">Archive</span>
-                                </div>
-                            </div>
-                            <p>A grouped collection of spreads and booklet layouts, focused on pacing, hierarchy, and longer-form editorial structure.</p>
-                            <div class="project-tags">
-                                <span class="tag">Booklet Design</span>
-                                <span class="tag">Spreads</span>
-                                <span class="tag">Editorial Layout</span>
-                                <span class="tag">Typography</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="book-open"></i>
-                                    <span>Multi-page design</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="align-left"></i>
-                                    <span>Layout studies</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="project-card archive-card" data-category="campaign editorial motion">
-                        <div class="project-image">
-                            <picture>
-                                <source
-                                    type="image/avif"
-                                    srcset="media/archive/northface-home-320.avif 320w, media/archive/northface-home-360.avif 360w, media/archive/northface-home-375.avif 375w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px">
-                                <source
-                                    type="image/webp"
-                                    srcset="media/archive/northface-home-320.webp 320w, media/archive/northface-home-360.webp 360w, media/archive/northface-home-375.webp 375w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px">
-                                <img
-                                    src="media/archive/northface-home-360.png"
-                                    srcset="media/archive/northface-home-320.png 320w, media/archive/northface-home-360.png 360w, media/archive/northface-home-375.png 375w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px"
-                                    alt="Hidden Realms Fest social launch preview"
-                                    width="375"
-                                    height="812"
-                                    loading="lazy"
-                                    decoding="async">
-                            </picture>
-                            <div class="project-overlay">
-                                <div class="project-actions">
-                                    <button class="btn btn-primary view-details" data-project="hidden-realms-fest">
-                                        <i data-feather="layers"></i>
-                                        View Collection
-                                    </button>
-                                    <button class="btn btn-secondary video-play" data-video="videos/archive/northface-teaser.mp4" data-title="Hidden Realms Fest Teaser">
-                                        <i data-feather="play-circle"></i>
-                                        Play Teaser
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="project-content">
-                            <p class="project-kicker">Festival brand rollout</p>
-                            <div class="project-header">
-                                <h3>Hidden Realms Fest</h3>
-                                <div class="project-status">
-                                    <span class="status-badge archive">Archive</span>
-                                </div>
-                            </div>
-                            <p>A separate festival project that combines identity boards, social launch assets, and motion teasers into one consistent event-world campaign.</p>
-                            <div class="project-tags">
-                                <span class="tag">Moodboard</span>
-                                <span class="tag">Social Campaign</span>
-                                <span class="tag">Motion Teasers</span>
-                                <span class="tag">Event Identity</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="image"></i>
-                                    <span>Identity + launch</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="play-circle"></i>
-                                    <span>Motion + social assets</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="project-card archive-card" data-category="campaign print">
-                        <div class="project-image">
-                            <picture>
-                                <source
-                                    type="image/avif"
-                                    srcset="media/archive/event-kit/flyer-01-360.avif 360w, media/archive/event-kit/flyer-01-640.avif 640w, media/archive/event-kit/flyer-01-960.avif 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px">
-                                <source
-                                    type="image/webp"
-                                    srcset="media/archive/event-kit/flyer-01-360.webp 360w, media/archive/event-kit/flyer-01-640.webp 640w, media/archive/event-kit/flyer-01-960.webp 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px">
-                                <img
-                                    src="media/archive/event-kit/flyer-01-640.jpg"
-                                    srcset="media/archive/event-kit/flyer-01-360.jpg 360w, media/archive/event-kit/flyer-01-640.jpg 640w, media/archive/event-kit/flyer-01-960.jpg 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px"
-                                    alt="Event promotion flyer and ticket design"
-                                    width="1127"
-                                    height="1600"
-                                    loading="lazy"
-                                    decoding="async">
-                            </picture>
-                            <div class="project-overlay">
-                                <div class="project-actions">
-                                    <button class="btn btn-primary view-details" data-project="event-promo-pack">
-                                        <i data-feather="layers"></i>
-                                        View Collection
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="project-content">
-                            <p class="project-kicker">Print rollout</p>
-                            <div class="project-header">
-                                <h3>Event Identity Kit</h3>
-                                <div class="project-status">
-                                    <span class="status-badge archive">Archive</span>
-                                </div>
-                            </div>
-                            <p>A set of promotional assets that bundles flyers, tickets, and supporting print pieces into one event identity across announcement and attendance touchpoints.</p>
-                            <div class="project-tags">
-                                <span class="tag">Flyers</span>
-                                <span class="tag">Tickets</span>
-                                <span class="tag">Event Design</span>
-                                <span class="tag">Promo Assets</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="tag"></i>
-                                    <span>Entry materials</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="flag"></i>
-                                    <span>Campaign support</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="project-card archive-card" data-category="print">
-                        <div class="project-image">
-                            <picture>
-                                <source
-                                    type="image/avif"
-                                    srcset="media/archive/posters/poster-bowie-360.avif 360w, media/archive/posters/poster-bowie-640.avif 640w, media/archive/posters/poster-bowie-960.avif 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px">
-                                <source
-                                    type="image/webp"
-                                    srcset="media/archive/posters/poster-bowie-360.webp 360w, media/archive/posters/poster-bowie-640.webp 640w, media/archive/posters/poster-bowie-960.webp 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px">
-                                <img
-                                    src="media/archive/posters/poster-bowie-640.jpg"
-                                    srcset="media/archive/posters/poster-bowie-360.jpg 360w, media/archive/posters/poster-bowie-640.jpg 640w, media/archive/posters/poster-bowie-960.jpg 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px"
-                                    alt="Poster experiments and promotional print design"
-                                    width="1261"
-                                    height="1800"
-                                    loading="lazy"
-                                    decoding="async">
-                            </picture>
-                            <div class="project-overlay">
-                                <div class="project-actions">
-                                    <button class="btn btn-primary view-details" data-project="poster-series">
-                                        <i data-feather="layers"></i>
-                                        View Collection
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="project-content">
-                            <p class="project-kicker">Poster studies</p>
-                            <div class="project-header">
-                                <h3>Poster Collection</h3>
-                                <div class="project-status">
-                                    <span class="status-badge archive">Archive</span>
-                                </div>
-                            </div>
-                            <p>A poster-led collection covering music, event, and image-treatment experiments, built around composition, contrast, and graphic impact.</p>
-                            <div class="project-tags">
-                                <span class="tag">Poster Design</span>
-                                <span class="tag">Image Editing</span>
-                                <span class="tag">Typography</span>
-                                <span class="tag">Print Visuals</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="layout"></i>
-                                    <span>Promotional formats</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="droplet"></i>
-                                    <span>Color explorations</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="project-card archive-card" data-category="editorial print">
-                        <div class="project-image">
-                            <picture>
-                                <source
-                                    type="image/avif"
-                                    srcset="media/archive/menu-system/menu-03-480.avif 480w, media/archive/menu-system/menu-03-768.avif 768w, media/archive/menu-system/menu-03-1200.avif 1200w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px">
-                                <source
-                                    type="image/webp"
-                                    srcset="media/archive/menu-system/menu-03-480.webp 480w, media/archive/menu-system/menu-03-768.webp 768w, media/archive/menu-system/menu-03-1200.webp 1200w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px">
-                                <img
-                                    src="media/archive/menu-system/menu-03-768.jpg"
-                                    srcset="media/archive/menu-system/menu-03-480.jpg 480w, media/archive/menu-system/menu-03-768.jpg 768w, media/archive/menu-system/menu-03-1200.jpg 1200w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 560px"
-                                    alt="Hospitality menu feature spread"
-                                    width="1600"
-                                    height="1135"
-                                    loading="lazy"
-                                    decoding="async">
-                            </picture>
-                            <div class="project-overlay">
-                                <div class="project-actions">
-                                    <button class="btn btn-primary view-details" data-project="menu-design-system">
-                                        <i data-feather="layers"></i>
-                                        View Collection
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="project-content">
-                            <p class="project-kicker">Information design</p>
-                            <div class="project-header">
-                                <h3>Hospitality Menu System</h3>
-                                <div class="project-status">
-                                    <span class="status-badge archive">Archive</span>
-                                </div>
-                            </div>
-                            <p>A hospitality-focused layout collection centered on readability, pricing hierarchy, and visual consistency across multiple menu pages.</p>
-                            <div class="project-tags">
-                                <span class="tag">Menu Design</span>
-                                <span class="tag">Print Layout</span>
-                                <span class="tag">Hospitality</span>
-                                <span class="tag">Information Design</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="file-text"></i>
-                                    <span>Multi-page menu</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="list"></i>
-                                    <span>Readable structure</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="project-card archive-card" data-category="campaign editorial print">
-                        <div class="project-image">
-                            <picture>
-                                <source
-                                    type="image/avif"
-                                    srcset="media/archive/research-boards/alternative-typo-360.avif 360w, media/archive/research-boards/alternative-typo-640.avif 640w, media/archive/research-boards/alternative-typo-960.avif 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px">
-                                <source
-                                    type="image/webp"
-                                    srcset="media/archive/research-boards/alternative-typo-360.webp 360w, media/archive/research-boards/alternative-typo-640.webp 640w, media/archive/research-boards/alternative-typo-960.webp 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px">
-                                <img
-                                    src="media/archive/research-boards/alternative-typo-640.jpg"
-                                    srcset="media/archive/research-boards/alternative-typo-360.jpg 360w, media/archive/research-boards/alternative-typo-640.jpg 640w, media/archive/research-boards/alternative-typo-960.jpg 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px"
-                                    alt="Alternative typography concept board"
-                                    width="1200"
-                                    height="1600"
-                                    loading="lazy"
-                                    decoding="async">
-                            </picture>
-                            <div class="project-overlay">
-                                <div class="project-actions">
-                                    <button class="btn btn-primary view-details" data-project="research-concept-boards">
-                                        <i data-feather="layers"></i>
-                                        View Collection
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="project-content">
-                            <p class="project-kicker">Process and concept</p>
-                            <div class="project-header">
-                                <h3>Research &amp; Concept Boards</h3>
-                                <div class="project-status">
-                                    <span class="status-badge archive">Archive</span>
-                                </div>
-                            </div>
-                            <p>A collection of research boards, collage explorations, and reference-led studies used to shape stronger visual directions before final execution.</p>
-                            <div class="project-tags">
-                                <span class="tag">Research</span>
-                                <span class="tag">Collage</span>
-                                <span class="tag">Concept Boards</span>
-                                <span class="tag">Visual References</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="search"></i>
-                                    <span>Direction setting</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="copy"></i>
-                                    <span>Reference grouping</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="project-card archive-card" data-category="photo">
-                        <div class="project-image">
-                            <picture>
-                                <source
-                                    type="image/avif"
-                                    srcset="media/archive/photo-series/photo-collage-360.avif 360w, media/archive/photo-series/photo-collage-640.avif 640w, media/archive/photo-series/photo-collage-960.avif 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px">
-                                <source
-                                    type="image/webp"
-                                    srcset="media/archive/photo-series/photo-collage-360.webp 360w, media/archive/photo-series/photo-collage-640.webp 640w, media/archive/photo-series/photo-collage-960.webp 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px">
-                                <img
-                                    src="media/archive/photo-series/photo-collage-640.jpg"
-                                    srcset="media/archive/photo-series/photo-collage-360.jpg 360w, media/archive/photo-series/photo-collage-640.jpg 640w, media/archive/photo-series/photo-collage-960.jpg 960w"
-                                    sizes="(max-width: 767px) calc(100vw - 2rem), (max-width: 1200px) calc(50vw - 3rem), 360px"
-                                    alt="Photography collage overview"
-                                    width="1273"
-                                    height="1800"
-                                    loading="lazy"
-                                    decoding="async">
-                            </picture>
-                            <div class="project-overlay">
-                                <div class="project-actions">
-                                    <button class="btn btn-primary view-details" data-project="photography-studies">
-                                        <i data-feather="layers"></i>
-                                        View Collection
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="project-content">
-                            <p class="project-kicker">Image study</p>
-                            <div class="project-header">
-                                <h3>Product Styling Photo Series</h3>
-                                <div class="project-status">
-                                    <span class="status-badge archive">Archive</span>
-                                </div>
-                            </div>
-                            <p>A visual study series built from styled product photography, composition experiments, and collage-based presentation around one object set.</p>
-                            <div class="project-tags">
-                                <span class="tag">Photography</span>
-                                <span class="tag">Styling</span>
-                                <span class="tag">Collage</span>
-                                <span class="tag">Art Direction</span>
-                            </div>
-                            <div class="project-stats">
-                                <div class="stat">
-                                    <i data-feather="camera"></i>
-                                    <span>Object studies</span>
-                                </div>
-                                <div class="stat">
-                                    <i data-feather="grid"></i>
-                                    <span>Collage presentation</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- Add more projects placeholder -->
-                   <!-- <div class="project-card coming-soon" data-category="web">
-                        <div class="project-image">
-                            <div class="coming-soon-content">
-                                <i data-feather="plus-circle"></i>
-                                <h4>More Projects Coming Soon</h4>
-                                <p>I'm always working on new and exciting projects</p>
-                            </div>
-                        </div>
-                        <div class="project-content">
-                            <h3>Stay Tuned</h3>
-                            <p>Follow my journey as I continue to build amazing digital experiences.</p>
-                            <a href="https://github.com/trijbs" target="_blank" rel="noopener noreferrer" class="btn btn-outline">
-                                <i data-feather="github"></i>
-                                Follow on GitHub
-                            </a>
-                        </div>
-                    </div> > -->
-                    
-                </div>
+                </div><!-- /projects-grid -->
             </div>
         </section>
 
-        <!-- Contact Section -->
+        <!-- ================================================
+             CONTACT
+        ================================================ -->
         <section id="contact" class="contact-section">
             <div class="container">
                 <div class="section-header">
-                    <span class="section-tag">Let&apos;s Build Something Better</span>
-                    <h2 class="section-title">Need a designer who can shape<br>the look and the experience?</h2>
-                    <p class="section-description">I&apos;m available for portfolio sites, landing pages, design concepts, creative web experiences, and interface refreshes that need a stronger visual direction.</p>
+                    <span class="section-tag">Get in Touch</span>
+                    <h2 class="section-title">Have something interesting<br>you want to build?</h2>
+                    <p class="section-description">I&apos;m available for interface design, interactive web experiences, brand identities, and builds where design and code need to work together from the start.</p>
                 </div>
-                
+
                 <div class="contact-container">
                     <div class="contact-info">
                         <div class="contact-card">
-                            <h3>Start a Design-Led Project</h3>
-                            <p>If you need a website or interface that should feel sharper, clearer, and more intentional, send me the idea and I can help shape the direction.</p>
-                            
+                            <h3>Let&apos;s make something worth making</h3>
+                            <p>If you have a project that needs a designer who can also build it &mdash; or an idea you want to develop from a blank page &mdash; send me what you have in mind.</p>
+
                             <div class="contact-methods">
                                 <div class="contact-method">
                                     <div class="method-icon">
@@ -1403,10 +758,10 @@
                                     <div class="method-info">
                                         <h4>Email</h4>
                                         <a href="mailto:rbdegroot@gmail.com">rbdegroot@gmail.com</a>
-                                        <span class="response-time">Best for project inquiries and freelance work</span>
+                                        <span class="response-time">Best for project inquiries</span>
                                     </div>
                                 </div>
-                                
+
                                 <div class="contact-method">
                                     <div class="method-icon">
                                         <i data-feather="github"></i>
@@ -1414,10 +769,10 @@
                                     <div class="method-info">
                                         <h4>GitHub</h4>
                                         <a href="https://github.com/trijbs" target="_blank" rel="noopener noreferrer">@trijbs</a>
-                                        <span class="response-time">See how design ideas translate into build quality</span>
+                                        <span class="response-time">See the code behind the work</span>
                                     </div>
                                 </div>
-                                
+
                                 <div class="contact-method">
                                     <div class="method-icon">
                                         <i data-feather="instagram"></i>
@@ -1425,23 +780,23 @@
                                     <div class="method-info">
                                         <h4>Instagram</h4>
                                         <a href="https://www.instagram.com/trijbsworld/" target="_blank" rel="noopener noreferrer">@trijbsworld</a>
-                                        <span class="response-time">Creative direction and visual inspiration</span>
+                                        <span class="response-time">Process and visual work</span>
                                     </div>
                                 </div>
                             </div>
-                            
+
                             <div class="availability-status">
                                 <div class="status-indicator available"></div>
-                                <span>Available for new UI/UX and web design projects</span>
+                                <span>Available for new projects</span>
                             </div>
                         </div>
                     </div>
-                    
+
                     <div class="contact-form">
                         <div class="form-card">
-                            <h3>Tell Me What You Want the Site to Feel Like</h3>
-                            <p>Share the goal, audience, and style you have in mind. I&apos;ll reply with how I would approach the design and build.</p>
-                            
+                            <h3>Start a conversation</h3>
+                            <p>Share the goal and context. I&apos;ll reply with how I&apos;d approach it.</p>
+
                             <form id="contactForm" class="contact-form-inner">
                                 <div class="form-row">
                                     <div class="form-group">
@@ -1454,27 +809,27 @@
                                     </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="subject">Subject *</label>
+                                    <label for="subject">Type of project</label>
                                     <select id="subject" name="subject">
-                                        <option value="">Select a subject</option>
-                                        <option value="landing-page">Landing Page Design</option>
-                                        <option value="portfolio">Portfolio Website</option>
-                                        <option value="ecommerce">E-commerce UI</option>
-                                        <option value="redesign">Website Redesign</option>
-                                        <option value="other">Other</option>
+                                        <option value="">Select a type</option>
+                                        <option value="interactive">Interactive / Web Experience</option>
+                                        <option value="interface">Interface Design</option>
+                                        <option value="brand">Brand &amp; Identity</option>
+                                        <option value="fullstack">Full-stack Build</option>
+                                        <option value="other">Other / Not sure yet</option>
                                     </select>
                                 </div>
                                 <div class="form-group">
-                                    <label for="message">Message</label>
-                                    <textarea id="message" name="message" rows="6" placeholder="Tell me about your project or inquiry..." required></textarea>
+                                    <label for="message">Message *</label>
+                                    <textarea id="message" name="message" rows="6" placeholder="Tell me about the project, the goal, or even just the feeling you&apos;re going for..." required></textarea>
                                 </div>
-                                
+
                                 <button type="submit" class="btn btn-primary submit-btn">
                                     <i data-feather="send"></i>
                                     Send Message
                                 </button>
                                 <p class="form-note">
-                                    I&apos;ll get back to you within 24 hours. If you already have references or a moodboard, include them in your message.
+                                    I reply within 24 hours. If you have references or a moodboard, include them in your message.
                                 </p>
                             </form>
                         </div>
@@ -1489,140 +844,103 @@
             <div class="footer-content">
                 <div class="footer-top">
                     <div class="footer-column">
-                        <h4>Navigation</h4>
+                        <h4>Navigate</h4>
                         <div class="footer-links">
                             <a href="#about">About</a>
-                            <a href="#skills">Skills</a>
-                            <a href="#projects">Projects</a>
+                            <a href="#skills">Practice</a>
+                            <a href="#projects">Work</a>
                             <a href="#contact">Contact</a>
                         </div>
                     </div>
                     <div class="footer-column">
-                        <h4>Projects</h4>
+                        <h4>Worlds</h4>
                         <div class="footer-links">
-                            <a href="#projects">UI/UX Design</a>
-                            <a href="#projects">Web Design</a>
-                            <a href="#projects">Creative Concepts</a>
+                            <a href="https://mvxworld.art" target="_blank" rel="noopener noreferrer">mvxworld.art</a>
+                            <a href="https://github.com/Trijbs" target="_blank" rel="noopener noreferrer">GitHub</a>
+                            <a href="/info.html">Info</a>
                         </div>
                     </div>
                     <div class="footer-column">
                         <h4>Connect</h4>
                         <div class="footer-links">
-                            <a href="mailto:trjbs@icloud.com">Email</a>
-                            <a href="https://github.com/trijbs" target="_blank" rel="noopener noreferrer">GitHub</a>
+                            <a href="mailto:rbdegroot@gmail.com">Email</a>
                             <a href="https://www.instagram.com/trijbsworld/" target="_blank" rel="noopener noreferrer">Instagram</a>
                             <a href="https://nl.pinterest.com/closesz/" target="_blank" rel="noopener noreferrer">Pinterest</a>
-                            <a href="#contact">Contact Form</a>
                         </div>
                     </div>
-                    <div class="footer-column footer-newsletter">
-                        <h4>Design Updates</h4>
-                        <p>Subscribe for new projects, design experiments, and portfolio updates.</p>
-                        <form class="newsletter-form">
-                            <input type="email" placeholder="Your email address" required>
-                            <button type="submit">
-                                <i data-feather="send"></i>
-                            </button>
-                        </form>
+                    <div class="footer-column">
+                        <h4>Also</h4>
+                        <div class="footer-links">
+                            <a href="https://mvxworld.art" target="_blank" rel="noopener noreferrer">Personal Universe</a>
+                            <a href="https://weekplanner.trijbsworld.nl" target="_blank" rel="noopener noreferrer">WeekPlanner App</a>
+                        </div>
                     </div>
                 </div>
-                
+
                 <div class="footer-bottom">
                     <div class="copyright">
-                        <p>&copy; 2026 Trijbs | UI/UX &amp; Web Designer</p>
+                        <p>&copy; 2026 Ruben Trijbels &mdash; <a href="https://mvxworld.art" target="_blank" rel="noopener noreferrer">mvxworld.art</a></p>
                     </div>
                 </div>
             </div>
         </div>
     </footer>
 
-    <!-- Project Modal -->
-    <div class="modal" id="projectModal">
-        <div class="modal-content">
-            <button class="close-modal" aria-label="Close modal">
+    <!-- Project Detail Modal -->
+    <div class="modal" id="projectModal" role="dialog" aria-modal="true" aria-label="Project details">
+        <div class="modal-container">
+            <button class="close-modal" aria-label="Close project details">
                 <i data-feather="x"></i>
             </button>
-            <div class="modal-body">
-                <!-- Content will be dynamically inserted here -->
-            </div>
-        </div>
-    </div>
-
-    <!-- Project Details Modal -->
-    <div class="modal project-details-modal" id="projectDetailsModal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title" id="projectDetailsTitle">Project Details</h3>
-                <div class="modal-actions">
-                    <button class="close-modal" aria-label="Close modal">
-                        <i data-feather="x"></i>
-                    </button>
-                </div>
-            </div>
-            <div class="modal-body" id="projectDetailsBody">
-                <!-- Content will be dynamically inserted here -->
-            </div>
-        </div>
-    </div>
-
-    <!-- Live Demo Modal -->
-    <div class="modal live-demo-modal" id="liveDemoModal">
-        <div class="modal-content live-demo-content">
-            <div class="modal-header">
-                <h3 class="modal-title" id="liveDemoTitle">Live Demo</h3>
-                <div class="modal-actions">
-                    <button class="btn btn-outline open-external" id="openExternal" title="Open in new tab">
-                        <i data-feather="external-link"></i>
-                        Open External
-                    </button>
-                    <button class="close-modal" aria-label="Close modal">
-                        <i data-feather="x"></i>
-                    </button>
-                </div>
-            </div>
-            <div class="modal-body iframe-container">
-                <iframe id="liveDemoFrame" src="" frameborder="0" allowfullscreen 
-                        sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
-                        loading="lazy"></iframe>
-                <div class="loading-spinner">
-                    <div class="spinner"></div>
-                    <p>Loading demo...</p>
-                </div>
-            </div>
+            <div class="modal-body"></div>
         </div>
     </div>
 
     <!-- Video Modal -->
-    <div class="modal video-modal" id="videoModal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title" id="videoModalTitle">Video</h3>
-                <div class="modal-actions">
-                    <button class="close-modal" aria-label="Close modal">
-                        <i data-feather="x"></i>
-                    </button>
-                </div>
-            </div>
+    <div class="modal video-modal" id="videoModal" role="dialog" aria-modal="true" aria-label="Video player">
+        <div class="modal-container">
+            <button class="close-modal" aria-label="Close video" id="closeVideoModal">
+                <i data-feather="x"></i>
+            </button>
             <div class="modal-body">
-                <div class="video-container">
-                    <video id="modalVideo" controls preload="metadata" playsinline>
-                        Your browser does not support the video tag.
+                <div class="video-modal-title" id="videoModalTitle"></div>
+                <div class="video-wrapper">
+                    <video id="modalVideo" controls playsinline>
+                        <source id="modalVideoSource" src="" type="video/mp4">
+                        Your browser does not support HTML5 video.
                     </video>
                 </div>
             </div>
         </div>
     </div>
 
-    <div class="modal image-zoom-modal" id="imageZoomModal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title" id="imageZoomTitle">Image Preview</h3>
-                <div class="modal-actions">
-                    <button class="close-modal" aria-label="Close image preview">
+    <!-- Demo Modal -->
+    <div class="modal demo-modal" id="demoModal" role="dialog" aria-modal="true" aria-label="Live demo">
+        <div class="modal-container demo-modal-container">
+            <div class="demo-modal-header">
+                <h3 id="demoModalTitle">Live Demo</h3>
+                <div class="demo-modal-actions">
+                    <a href="#" id="demoModalExternalLink" target="_blank" rel="noopener noreferrer" class="btn btn-secondary btn-sm">
+                        <i data-feather="external-link"></i>
+                        Open in Tab
+                    </a>
+                    <button class="close-modal" id="closeDemoModal" aria-label="Close demo">
                         <i data-feather="x"></i>
                     </button>
                 </div>
             </div>
+            <div class="demo-iframe-wrapper">
+                <iframe id="demoFrame" src="" title="Live demo" loading="lazy" sandbox="allow-scripts allow-same-origin allow-forms allow-popups"></iframe>
+            </div>
+        </div>
+    </div>
+
+    <!-- Image Zoom Modal -->
+    <div class="modal image-zoom-modal" id="imageZoomModal" role="dialog" aria-modal="true" aria-label="Zoomed image">
+        <div class="modal-container">
+            <button class="close-modal" aria-label="Close image zoom">
+                <i data-feather="x"></i>
+            </button>
             <div class="modal-body">
                 <div class="image-zoom-stage" id="imageZoomStage">
                     <button class="image-zoom-toggle" id="imageZoomToggle" type="button" aria-label="Zoom image">
@@ -1639,37 +957,25 @@
 
     <!-- Core Scripts -->
     <script src="js/vendor/feather.min.js?v=2.2.0"></script>
-    <script src="js/main.js?v=2.3.0"></script>
+    <script src="js/main.js?v=3.0.0"></script>
     <script src="js/easter-eggs.js?v=2.3.0"></script>
-    
-    <!-- Vercel Analytics -->
     <script src="js/vercel-analytics.js?v=2.2.0"></script>
-    
-    <!-- Privacy Controls & GDPR Compliance -->
     <script src="js/privacy-controls.js?v=2.2.0"></script>
-    
-    <!-- Enhanced Contact Form -->
     <script src="js/contact-form.js?v=2.2.0"></script>
-    
+
     <script>
-      // Initialize Feather icons and wire up modal behavior
       document.addEventListener('DOMContentLoaded', () => {
-        if (window.feather) {
-          feather.replace();
-        }
-        
-        // Mobile menu toggle
+        if (window.feather) feather.replace();
+
+        // Mobile menu
         const bodyEl = document.body;
         const nav = document.getElementById('primary-nav');
         const menuBtn = document.querySelector('.mobile-menu-toggle');
-        
         function setMenuState(open) {
           bodyEl.classList.toggle('nav-open', open);
-          document.body.classList.toggle('nav-open', open);
           document.body.style.overflow = open ? 'hidden' : '';
           menuBtn.setAttribute('aria-expanded', String(open));
           menuBtn.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
-          
           const iconMenu = menuBtn.querySelector('.icon-menu');
           const iconClose = menuBtn.querySelector('.icon-close');
           if (iconMenu && iconClose) {
@@ -1677,48 +983,29 @@
             iconClose.style.display = open ? '' : 'none';
           }
         }
-        
-        menuBtn.addEventListener('click', () => {
-          setMenuState(!bodyEl.classList.contains('nav-open'));
-        });
-        
-        // Close when clicking a nav link
-        nav.querySelectorAll('a[href^="#"]').forEach(a => {
-          a.addEventListener('click', () => setMenuState(false));
-        });
-        
-        // Reset on resize to desktop
+        menuBtn.addEventListener('click', () => setMenuState(!bodyEl.classList.contains('nav-open')));
+        nav.querySelectorAll('a[href^="#"]').forEach(a => a.addEventListener('click', () => setMenuState(false)));
         window.addEventListener('resize', () => {
-          if (window.innerWidth >= 1024 && bodyEl.classList.contains('nav-open')) {
-            setMenuState(false);
-          }
+          if (window.innerWidth >= 1024 && bodyEl.classList.contains('nav-open')) setMenuState(false);
         });
 
-        // Project Modal functionality
+        // Project modal
         const modal = document.getElementById('projectModal');
-        const modalBody = modal.querySelector('.modal-body');
-        const closeBtn = modal.querySelector('.close-modal');
-
-        function openModalWithContent(html) {
-          modalBody.innerHTML = html;
-          modal.classList.add('open');
-          document.body.style.overflow = 'hidden';
-        }
-
+        const modalBody = modal ? modal.querySelector('.modal-body') : null;
+        const closeBtn = modal ? modal.querySelector('.close-modal') : null;
         function closeModal() {
+          if (!modal) return;
           modal.classList.remove('open');
-          modalBody.innerHTML = '';
+          if (modalBody) modalBody.innerHTML = '';
           document.body.style.overflow = '';
         }
-
-        // Close interactions
-        closeBtn.addEventListener('click', closeModal);
-        modal.addEventListener('click', (e) => {
-          if (e.target === modal) closeModal();
-        });
-        document.addEventListener('keydown', (e) => {
-          if (e.key === 'Escape' && modal.classList.contains('open')) closeModal();
-        });
+        if (closeBtn) closeBtn.addEventListener('click', closeModal);
+        if (modal) {
+          modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
+          document.addEventListener('keydown', e => {
+            if (e.key === 'Escape' && modal.classList.contains('open')) closeModal();
+          });
+        }
       });
     </script>
 </body>

--- a/public/info.html
+++ b/public/info.html
@@ -3,9 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Info | Ruben Trijbs</title>
+    <title>Info | Trijbs</title>
+    <meta name="description" content="Contact info, links, and a quiet collection of sites that feel inspiring, inventive, or just nicely made.">
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="css/styles.css?v=2.3.0">
+    <link rel="preload" href="/fonts/manrope-latin.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="/fonts/space-grotesk-latin.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="/fonts/ibm-plex-mono-400-latin.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="stylesheet" href="css/styles.css?v=3.0.0">
     <script src="js/vendor/feather.min.js?v=2.2.0"></script>
 </head>
 <body class="theme-poster">
@@ -16,17 +20,21 @@
                     <span class="logo-text">trijbs</span>
                 </a>
             </div>
-            <nav class="main-nav">
+            <nav class="main-nav" id="primary-nav">
                 <ul>
                     <li><a href="/#about">About</a></li>
-                    <li><a href="/#skills">Skills</a></li>
-                    <li><a href="/#projects">Projects</a></li>
+                    <li><a href="/#skills">Practice</a></li>
+                    <li><a href="/#projects">Work</a></li>
                     <li><a href="/#contact">Contact</a></li>
-                    <li><a href="/info.html">Info</a></li>
+                    <li><a href="/info.html" aria-current="page">Info</a></li>
                 </ul>
             </nav>
             <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
                 <i data-feather="moon"></i>
+            </button>
+            <button class="mobile-menu-toggle" aria-label="Open menu" aria-controls="primary-nav" aria-expanded="false">
+                <i data-feather="menu" class="icon-menu"></i>
+                <i data-feather="x" class="icon-close" style="display:none"></i>
             </button>
         </div>
     </header>
@@ -34,19 +42,21 @@
     <main style="padding-top: 100px;">
         <section class="info-section">
             <div class="container">
-                <h1>Portfolio Information</h1>
-                
-                <div class="info-content"> 
-                    <p>This section provides detailed contact information and links to my social profiles.</p>
 
+                <h1>Info</h1>
+
+                <div class="info-content">
+
+                    <!-- Contact -->
                     <div class="info-links">
-                        <h2>Contact Information</h2>
+                        <h2>Contact</h2>
                         <p>Email: <a href="mailto:rbdegroot@gmail.com">rbdegroot@gmail.com</a></p>
-                        <p>GitHub: <a href="https://github.com/trijbs" target="_blank">@trijbs</a></p>
-                        <p>Instagram: <a href="https://www.instagram.com/trijbsworld/" target="_blank">@trijbsworld</a></p>
-                        <p>Pinterest: <a href="https://nl.pinterest.com/closesz/" target="_blank">closesz</a></p>
+                        <p>GitHub: <a href="https://github.com/trijbs" target="_blank" rel="noopener noreferrer">@trijbs</a></p>
+                        <p>Instagram: <a href="https://www.instagram.com/trijbsworld/" target="_blank" rel="noopener noreferrer">@trijbsworld</a></p>
+                        <p>Pinterest: <a href="https://nl.pinterest.com/closesz/" target="_blank" rel="noopener noreferrer">closesz</a></p>
                     </div>
-                    
+
+                    <!-- Cool Links — content preserved exactly as original -->
                     <section class="info-links info-links-subtle" aria-labelledby="cool-links-title">
                         <span class="info-links-eyebrow">Collected</span>
                         <h2 id="cool-links-title">Cool Links</h2>
@@ -56,21 +66,55 @@
                             <li><a href="https://pointerpointer.com" target="_blank" rel="noopener noreferrer">Pointer Pointer</a></li>
                             <li><a href="https://simone.computer" target="_blank" rel="noopener noreferrer">Simone Computer</a></li>
                             <li><a href="https://theuselessweb.com" target="_blank" rel="noopener noreferrer">The Useless Web</a></li>
-                            <li><a href="https://www.instagram.com/soph.hackmanart/?hl=en" target="_blank" rel="noopener noreferrer">Sophie Hackmanart</li>
+                            <li><a href="https://www.instagram.com/soph.hackmanart/?hl=en" target="_blank" rel="noopener noreferrer">Sophie Hackmanart</a></li>
                         </ul>
                     </section>
+
                 </div>
             </div>
         </section>
     </main>
 
-    <script src="js/vercel-analytics.js?v=2.1.3"></script>
-    <script src="js/privacy-controls.js?v=2.1.3"></script>
-    <script src="js/main.js?v=2.3.0"></script>
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-bottom">
+                    <div class="copyright">
+                        <p>&copy; 2026 Ruben Trijbels &mdash; <a href="https://mvxworld.art" target="_blank" rel="noopener noreferrer">mvxworld.art</a></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="js/vercel-analytics.js?v=2.2.0"></script>
+    <script src="js/privacy-controls.js?v=2.2.0"></script>
+    <script src="js/main.js?v=3.0.0"></script>
     <script src="js/easter-eggs.js?v=2.3.0"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            feather.replace();
+            if (window.feather) feather.replace();
+
+            const bodyEl = document.body;
+            const nav = document.getElementById('primary-nav');
+            const menuBtn = document.querySelector('.mobile-menu-toggle');
+            if (menuBtn) {
+                function setMenuState(open) {
+                    bodyEl.classList.toggle('nav-open', open);
+                    document.body.style.overflow = open ? 'hidden' : '';
+                    menuBtn.setAttribute('aria-expanded', String(open));
+                    const iconMenu = menuBtn.querySelector('.icon-menu');
+                    const iconClose = menuBtn.querySelector('.icon-close');
+                    if (iconMenu && iconClose) {
+                        iconMenu.style.display = open ? 'none' : '';
+                        iconClose.style.display = open ? '' : 'none';
+                    }
+                }
+                menuBtn.addEventListener('click', () => setMenuState(!bodyEl.classList.contains('nav-open')));
+                window.addEventListener('resize', () => {
+                    if (window.innerWidth >= 1024 && bodyEl.classList.contains('nav-open')) setMenuState(false);
+                });
+            }
         });
     </script>
 </body>


### PR DESCRIPTION
# Portfolio Overhaul v3.0 — Identity, Curation & New Projects

## What this PR does

A ground-up refinement of trijbsworld.nl. The goal was to make the portfolio feel unmistakably personal — not a template that could belong to anyone. Every section has been reviewed and most have been substantially rewritten or redesigned.

---

## Identity & copy changes

**Before:** "UI/UX & Web Designer" — generic agency framing, progress-bar skills, corporate filler text.

**After:** "Designer · Developer · Builder" — reflects the actual breadth of the practice, including creative coding, world-building, mobile apps, and automation. Copy throughout is first-person, direct, and specific.

- Hero headline: *"Making things that look right and feel earned."*
- Added a **currently block** to the hero — a live signal showing what's being built right now (`mvxworld.art`, `KAAR`)
- About section: complete rewrite. Honest about the multi-discipline practice, references specific projects (Three.js, Supabase), mentions mvxworld.art as a related creative universe
- Contact: rewritten from "need a designer?" to "have something worth building?" — better intent match

---

## Projects added (4)

### mvxworld.art — Featured
A personal identity hub and living archive built as a multi-page dark world. Custom design system (ink base + acid green), a manifest-driven transmissions engine, and six live rooms — all in vanilla HTML, CSS, and JS. No framework, no CMS. Shows world-building, design system thinking, and a deliberate creative voice.

### KAAR — React Native / Expo
A multiplayer touch-arena party app prototype. Everyone places a finger, the room locks in, and a dramatic reveal picks the outcome. Full brief, feature map, UX flow, design system, and architecture — built from scratch. Shows product thinking, multi-touch engineering, and TypeScript discipline.

### WeekPlanner — Next.js + Supabase
A structured week planner with hourly time blocks, assignees, thought threads, and real-time sync. Production-grade: CodeQL scanning, cron automation, PWA setup, proper migrations. Shows full-stack capability from design mockup through to deployed app.

### Tainment — Python + Node.js Discord bot ecosystem
Casino mechanics, fishing games, trivia, leaderboards, birthday tracking, and admin subscriptions — two bots across two runtimes. Built because it should exist. Shows automation instinct and systems thinking outside of interface work.

---

## Projects removed (12)

| Project | Reason removed |
|---|---|
| Figma E-commerce UI (opdracht 10) | Student assignment, generic Figma exercise |
| SIRE Diabetes Campaign | Weak print work, doesn't hold up |
| Figurative Photo Spread | Educational exercise, not a portfolio piece |
| Video Editing Remake | 50-second edit study — too minor |
| Animated Infographic | Motion study, weak execution |
| Research & Concept Boards | Pre-production work, not deliverables |
| Editorial Layout Collection | Too student-y, lowers overall quality |
| Poster Collection | Weak individual pieces, no coherent identity |
| Event Identity Kit | Generic event design |
| Hospitality Menu System | Very weak — menu layout exercise |
| Product Styling Photo Series | Not relevant to current direction |
| E-commerce Platform / Webshop | Demoted to design archive, not removed entirely |

**Kept in design archive:** North Face Digital Campaign, Iris van Herpen Exhibition, Hidden Realms Fest — all genuinely strong design work.

---

## Design & UX improvements

### Skills section → Practice disciplines
Replaced the progress-bar skills section (a cliché that communicates nothing real) with a 4-card **Practice grid**: Interface Design / Creative Coding / Brand & Identity / Build & Automate. Each card has an honest description and relevant tech tags. No fake percentages.

### Project filters simplified
Old: `All / UI UX / Campaign / Editorial / Print / Motion / Photo` — too granular for the new project set.

New: `All / Interactive / Design / Build` — maps cleanly to the actual work and the practice disciplines.

### Code-preview cards
New projects without screenshots (mvxworld, KAAR, WeekPlanner, Tainment) use styled **code-preview** cards — dark backgrounds with accent color glow, terminal-style project metadata, and a sigil/name treatment. Significantly better than missing images or placeholder grays.

### Removed fake stats
`2.5k views`, `4.8/5 rating`, `1.8k views`, `156 likes` — all removed. They were clearly fabricated and damaged trust.

### Currently block
A new component in the hero that shows live status: what's being built, what's shipping, what's being thought about. Borrowed from the mvxworld.art status system — gives the portfolio a pulse.

### Info page
Preserved all content (contacts, Cool Links) exactly. Improved layout: better typography hierarchy, proper eyebrow labels, consistent arrow-link pattern on the quiet-links list, footer added, mobile menu wired correctly.

### Footer
Updated from generic nav links to: Navigate / Worlds / Connect / Also — with mvxworld.art and WeekPlanner linked.

---

## CSS additions (v3.0.0, +378 lines)

New component styles appended to `styles.css`:

- `.currently-block` + `.currently-label`
- `.practice-grid` + `.practice-card` + `.practice-tags` + `.practice-number`
- `.code-preview-card` + `.code-preview` + `.code-preview-inner` + `.code-preview-sigil` + `.cpl-*`
- `.status-badge.build`
- Info page: `.info-section`, `.info-links`, `.info-links-eyebrow`, `.quiet-links`
- Hero grain overlay via `::after` pseudo-element
- `display: none` on legacy `.skill-item`, `.skill-bar`, `.project-stats` (backwards compat)
- Dark theme and reduced-motion overrides for all new components

---

## Recommended future enhancements

1. **Screenshot assets for new projects** — mvxworld.art, KAAR, WeekPlanner, and Tainment all have code-preview cards. Real screenshots would upgrade these cards substantially. For mvxworld, a dark full-width capture works perfectly.

2. **Project detail modals for new entries** — The modal system is wired up. The project-details.json has been populated with rich descriptions for all 4 new projects; the modal will display them correctly once screenshots are added.

3. **Live status from status.json** — The `currently` block in the hero is currently hardcoded. Could be driven by the same `status.json` pattern used on mvxworld.art, fetched on page load.

4. **Lab page** — A `lab.html` exists in the repo but isn't linked in the main nav. If there are experiments worth showing, this is a natural place to route overflow/in-progress work.

5. **OG image update** — The current `og:image` points to the profile photo. A branded OG card (dark, with the "trijbs" wordmark and headline) would improve link previews significantly.

6. **mvxworld.art cross-link** — The portfolio now links to mvxworld.art in multiple places. It would be worth ensuring mvxworld.art links back to trijbsworld.nl for discoverability.

---

## Files changed

| File | Change |
|---|---|
| `public/index.html` | Full overhaul — hero, about, practice section, projects, contact, footer |
| `public/info.html` | Layout improved, content preserved exactly, mobile menu fixed |
| `public/data/project-details.json` | 4 new entries added, 11 entries removed |
| `public/css/styles.css` | +378 lines of new component styles appended |
